### PR TITLE
Refactor common config properties for max retires

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/common/ErrorHandler/HandleRetriableError.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/common/ErrorHandler/HandleRetriableError.scala
@@ -2,8 +2,12 @@ package com.microsoft.azure.cosmosdb.kafka.connect.common.ErrorHandler
 
 import com.typesafe.scalalogging.StrictLogging
 import java.util.Date
+import java.util
+
 import org.apache.kafka.connect.errors.{ConnectException, RetriableException}
 import scala.util.{Failure, Success, Try}
+
+import com.microsoft.azure.cosmosdb.kafka.connect.config.{ConnectorConfig, CosmosDBConfig, CosmosDBConfigConstants}
 
 
 case class ErrorHandlerObj(remainingRetries: Int, maxRetries: Int, errorMessage: String, lastErrorTimestamp: Date)
@@ -12,13 +16,21 @@ case class ErrorHandlerObj(remainingRetries: Int, maxRetries: Int, errorMessage:
 trait HandleRetriableError extends StrictLogging{
 
   var errorHandlerObj: Option[ErrorHandlerObj] = None
+  private var commonConfigDef : util.Map[String, String] = _
+  private var maxRetriesDefault = CosmosDBConfigConstants.ERROR_MAX_RETRIES_DEFAULT
+
 
   def initializeErrorHandler(maxRetries: Int): Unit = {
     errorHandlerObj = Some(ErrorHandlerObj(maxRetries, maxRetries, "", new Date()))
   }
 
   def HandleRetriableError[A](t : Try[A]) : Option[A] = {
-    require(errorHandlerObj.isDefined, "ErrorHandler is not set call. Please call initializeErrorHandler first.")
+    if(!errorHandlerObj.isDefined) {
+      logger.info(s"HandleRetriableError not initialized, getting max Retires value")
+      val errorHandlerConfig: CosmosDBConfig = CosmosDBConfig(ConnectorConfig.commonConfigDef, commonConfigDef)
+      maxRetriesDefault = errorHandlerConfig.getInt(CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_CONFIG)
+      initializeErrorHandler(maxRetriesDefault)
+    }
     t
     match {
       case Success(s) => {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/config/CosmosDBConfig.scala
@@ -37,11 +37,6 @@ object ConnectorConfig {
     .define(CosmosDBConfigConstants.TOPIC_CONFIG, Type.STRING, Importance.HIGH,
       CosmosDBConfigConstants.TOPIC_CONFIG_DOC, "Topic", 1, Width.MEDIUM,
       CosmosDBConfigConstants.TOPIC_CONFIG_DISPLAY)
-
-    .define(CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_CONFIG, Type.INT, Importance.HIGH,
-      CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_DOC, CosmosDBConfigConstants.ERROR_GROUP, 0
-      , Width.MEDIUM , CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_DISPLAY)
-
   /**
     * Holds the extra configurations for the source on top of
     * the base.
@@ -72,6 +67,12 @@ object ConnectorConfig {
   //        .define(CosmosDBConfigConstants.EXTRA_SINK_CONFIG_02, Type.STRING, Importance.HIGH,
   //          CosmosDBConfigConstants.EXTRA_SINK_CONFIG_02_DOC, "Sink", 2, Width.MEDIUM,
   //          CosmosDBConfigConstants.EXTRA_SINK_CONFIG_02_DISPLAY)
+
+  lazy val commonConfigDef: ConfigDef = ConnectorConfig.baseConfigDef
+    .define(CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_CONFIG, Type.INT, CosmosDBConfigConstants.ERROR_MAX_RETRIES_DEFAULT, Importance.MEDIUM,
+      CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_DOC, "Common", 1,
+      Width.MEDIUM , CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_DISPLAY)
+
 }
 
 case class CosmosDBConfig(config: ConfigDef, props: util.Map[String, String])

--- a/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/config/CosmosDBConfigConstants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/config/CosmosDBConfigConstants.scala
@@ -53,7 +53,6 @@ object CosmosDBConfigConstants {
     val ERRORS_RETRY_TIMEOUT_CONFIG = "errors.retry.timeout"
     val ERROR_MAX_RETRIES_DEFAULT = 3
     val ERRORS_RETRY_TIMEOUT_DISPLAY = "Retry Timeout for Errors"
-    val ERROR_GROUP = "Error Handling"
     val ERRORS_RETRY_TIMEOUT_DOC = "The maximum duration in milliseconds that a failed operation " +
                     "will be reattempted. The default is 0, which means no retries will be attempted. Use -1 for infinite retries.";
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkConnector.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkConnector.scala
@@ -15,8 +15,6 @@ class CosmosDBSinkConnector extends SinkConnector with HandleRetriableError{
 
 
   private var configProps: util.Map[String, String] = _
-  private var baseConfigProps : util.Map[String, String] = _
-  private var maxRetries = CosmosDBConfigConstants.ERROR_MAX_RETRIES_DEFAULT
 
 
   override def version(): String = getClass.getPackage.getImplementationVersion
@@ -24,11 +22,6 @@ class CosmosDBSinkConnector extends SinkConnector with HandleRetriableError{
   override def start(props: util.Map[String, String]): Unit = {
     logger.info("Starting CosmosDBSinkConnector")
 
-    val errorHandlerConfig: CosmosDBConfig = CosmosDBConfig(ConnectorConfig.baseConfigDef, baseConfigProps)
-    maxRetries = errorHandlerConfig.getInt(CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_CONFIG)
-    //initialize error handler
-
-    initializeErrorHandler(maxRetries)
 
     try {
       val config = Try(CosmosDBConfig(ConnectorConfig.sinkConfigDef, props))

--- a/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceConnector.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceConnector.scala
@@ -22,17 +22,12 @@ class CosmosDBSourceConnector extends SourceConnector with HandleRetriableError 
 
   private var configProps: util.Map[String, String] = _
   private var numWorkers: Int = 0
-  private var baseConfigProps : util.Map[String, String] = _
-  private var maxRetries = CosmosDBConfigConstants.ERROR_MAX_RETRIES_DEFAULT
 
   override def version(): String = getClass.getPackage.getImplementationVersion
 
   override def start(props: util.Map[String, String]): Unit = {
     logger.info("Starting CosmosDBSourceConnector")
     configProps = props
-    val errorHandlerConfig: CosmosDBConfig = CosmosDBConfig(ConnectorConfig.baseConfigDef, baseConfigProps)
-    maxRetries = errorHandlerConfig.getInt(CosmosDBConfigConstants.ERRORS_RETRY_TIMEOUT_CONFIG)
-    initializeErrorHandler(maxRetries)
   }
 
   override def taskClass(): Class[_ <: Task] = classOf[CosmosDBSourceTask]


### PR DESCRIPTION
- Move common config properties for max retires to a general class
- Remove unnecessary properties 