### PR TITLE
Fix contentResponseOnWriteEnabled

### DIFF
--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
@@ -136,6 +136,7 @@ public class CosmosDBSourceTask extends SourceTask {
                 .endpoint(this.settings.getEndpoint())
                 .key(this.settings.getKey())
                 .consistencyLevel(ConsistencyLevel.SESSION)
+                .contentResponseOnWriteEnabled(true)
                 .buildAsyncClient();
     }
 


### PR DESCRIPTION
Ensures that contentResponseOnWrite is enabled to use the ChangeFeedProcessorBuilder

## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Fix an issue when using the ChangeFeedProcessorBuilder that the contentResponseOnWrite is not enabled

## Review notes

## Issues Closed or Referenced
- Closes #150
