### PR TITLE
Making Config properties adhere to Sink or source connectors

### DIFF
--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/Settings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/Settings.java
@@ -23,7 +23,7 @@ public class Settings {
     private String databaseName;
     private TopicContainerMap topicContainerMap = TopicContainerMap.empty();
     private final List<Setting> allSettings = Arrays.asList(
-            // Add all common Source and Sink settings here:
+            //Add all common Source and Sink settings here:
             new Setting(PREFIX + ".connection.endpoint", "The Cosmos DB endpoint.", "CosmosDB Endpoint", this::setEndpoint, this::getEndpoint),
             new Setting(PREFIX + ".master.key", "The connection master key.", "Master Key", this::setKey, this::getKey),
             new Setting(PREFIX + ".databasename", "The Cosmos DB target database.", "CosmosDB Database Name", this::setDatabaseName, this::getDatabaseName),

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/Settings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/Settings.java
@@ -23,22 +23,12 @@ public class Settings {
     private String databaseName;
     private TopicContainerMap topicContainerMap = TopicContainerMap.empty();
     private final List<Setting> allSettings = Arrays.asList(
-            //Add all settings here:
-            new NumericSetting(PREFIX + ".task.timeout", "The max number of milliseconds the source task will use to read documents before send them to Kafka.",
-                    "Task Timeout", SettingDefaults.TASK_TIMEOUT, this::setTaskTimeout, this::getTaskTimeout),
-            new NumericSetting(PREFIX + ".task.buffer.size", "The max size the collection of documents the source task will buffer before send them to Kafka.",
-                    "Task reader buffer size", SettingDefaults.TASK_BUFFER_SIZE, this::setTaskBufferSize, this::getTaskBufferSize),
-            new NumericSetting(PREFIX + ".task.batch.size","The max number of of documents the source task will buffer before send them to Kafka.",
-                    "Task batch size", SettingDefaults.TASK_BATCH_SIZE, this::setTaskBatchSize, this::getTaskBatchSize),
-            new NumericSetting(PREFIX + ".task.poll.interval","The default polling interval in milli seconds that a source task polls for changes.",
-                    "Task poll interval", SettingDefaults.TASK_POLL_INTERVAL, this::setTaskPollInterval, this::getTaskPollInterval),
-            new Setting(PREFIX+".connection.endpoint", "The Cosmos DB endpoint.", "CosmosDB Endpoint", this::setEndpoint, this::getEndpoint),
-            new Setting(PREFIX+".master.key", "The connection master key.", "Master Key", this::setKey, this::getKey),
-            new Setting(PREFIX+".databasename", "The Cosmos DB target database.", "CosmosDB Database Name", this::setDatabaseName, this::getDatabaseName),
-            new Setting(PREFIX+".containers.topicmap", "A comma delimited list of collections mapped to their partitions. Formatted topic1#coll1,topic2#coll2.",
-                    "Topic-Container map", value -> this.setTopicContainerMap(TopicContainerMap.deserialize(value)), ()->this.getTopicContainerMap().serialize()),
-            new Setting(PREFIX+".containers", "A comma delimited list of source/target container names.",
-                    "Collection Names List", this::setContainerList, this::getContainerList)
+            // Add all common Source and Sink settings here:
+            new Setting(PREFIX + ".connection.endpoint", "The Cosmos DB endpoint.", "CosmosDB Endpoint", this::setEndpoint, this::getEndpoint),
+            new Setting(PREFIX + ".master.key", "The connection master key.", "Master Key", this::setKey, this::getKey),
+            new Setting(PREFIX + ".databasename", "The Cosmos DB target database.", "CosmosDB Database Name", this::setDatabaseName, this::getDatabaseName),
+            new Setting(PREFIX + ".containers.topicmap", "A comma delimited list of containers mapped to their topic partitions. Example: topic1#con1,topic2#con2.",
+                    "Topic-Container map", value -> this.setTopicContainerMap(TopicContainerMap.deserialize(value)), ()->this.getTopicContainerMap().serialize())
             );
 
 

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class SinkSettings extends Settings {
     private String postProcessor;
     private final List<Setting> sinkSettings = Arrays.asList(
-            // Add all sink settings here:
+            //Add all sink settings here:
             new Setting(Settings.PREFIX + ".sink.post-processor", "Comma-separated list of Sink Post-Processor class names to use for post-processing.",
                     "Sink post-processor", this::setPostProcessor, this::getPostProcessor),
 

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class SinkSettings extends Settings {
     private String postProcessor;
     private final List<Setting> sinkSettings = Arrays.asList(
-            //Add all settings here:
-            new Setting(Settings.PREFIX + ".sink.post-processor", "Comma-separated list of Sink Post-Processor class names to use for post-processing",
+            // Add all sink settings here:
+            new Setting(Settings.PREFIX + ".sink.post-processor", "Comma-separated list of Sink Post-Processor class names to use for post-processing.",
                     "Sink post-processor", this::setPostProcessor, this::getPostProcessor),
 
-            new Setting(SinkTask.TOPICS_CONFIG, "List of topics to consume, separated by commas", "Topics", s -> {
+            new Setting(SinkTask.TOPICS_CONFIG, "List of topics to consume, separated by commas.", "Topics", s -> {
             }, () -> ""),
             new Setting(SinkTask.TOPICS_REGEX_CONFIG,
                     "Regular expression giving topics to consume. " +

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
@@ -1,7 +1,9 @@
 package com.microsoft.azure.cosmosdb.kafka.connect.source;
 
 import com.microsoft.azure.cosmosdb.kafka.connect.BooleanSetting;
+import com.microsoft.azure.cosmosdb.kafka.connect.NumericSetting;
 import com.microsoft.azure.cosmosdb.kafka.connect.Setting;
+import com.microsoft.azure.cosmosdb.kafka.connect.SettingDefaults;
 import com.microsoft.azure.cosmosdb.kafka.connect.Settings;
 import org.apache.commons.collections4.ListUtils;
 
@@ -15,13 +17,24 @@ public class SourceSettings extends Settings {
     private String postProcessor;
     private boolean startFromBeginning;
     private final List<Setting> sourceSettings = Arrays.asList(
-            new Setting(Settings.PREFIX + ".source.post-processor", "Comma-separated list of Source Post-Processor class names to use for post-processing",
+            // Add all source settings here:
+            new NumericSetting(PREFIX + ".task.timeout", "The max number of milliseconds the source task will use to read documents before sending them to Kafka.",
+                    "Task Timeout", SettingDefaults.TASK_TIMEOUT, this::setTaskTimeout, this::getTaskTimeout),
+            new NumericSetting(PREFIX + ".task.buffer.size", "The max size the container of documents the source task will buffer before sending them to Kafka.",
+                    "Task reader buffer size", SettingDefaults.TASK_BUFFER_SIZE, this::setTaskBufferSize, this::getTaskBufferSize),
+            new NumericSetting(PREFIX + ".task.batch.size","The max number of of documents the source task will buffer before sending them to Kafka.",
+                    "Task batch size", SettingDefaults.TASK_BATCH_SIZE, this::setTaskBatchSize, this::getTaskBatchSize),
+            new NumericSetting(PREFIX + ".task.poll.interval","The default polling interval in milliseconds that a source task polls for changes.",
+                    "Task poll interval", SettingDefaults.TASK_POLL_INTERVAL, this::setTaskPollInterval, this::getTaskPollInterval),
+            new Setting(Settings.PREFIX + ".containers", "A comma delimited list of source container names.",
+                    "Container Names List", this::setContainerList, this::getContainerList),
+            new Setting(Settings.PREFIX + ".source.post-processor", "Comma-separated list of Source Post-Processor class names to use for post-processing.",
                     "Source post-processor", this::setPostProcessor, this::getPostProcessor),
-            new Setting(Settings.PREFIX + ".assigned.container", "The CosmosDB Feed Container assigned to the task.",
+            new Setting(Settings.PREFIX + ".assigned.container", "The Cosmos DB Feed Container assigned to the task.",
                     "Assigned Container", this::setAssignedContainer, this::getAssignedContainer),
-            new Setting(Settings.PREFIX + ".worker.name", "The CosmosDB worker name.",
+            new Setting(Settings.PREFIX + ".worker.name", "The Cosmos DB worker name.",
                     "Worker name", this::setWorkerName, this::getWorkerName),
-            new BooleanSetting(Settings.PREFIX + ".changefeed.startFromBeginning", "If the change feed should start from beginning",
+            new BooleanSetting(Settings.PREFIX + ".changefeed.startFromBeginning", "Whether the change feed should start from beginning.",
                     "Change Feed start from beginning", SourceSettingDefaults.CHANGE_FEED_START_FROM_BEGINNING, this::setStartFromBeginning, this::isStartFromBeginning)
 
     );

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
@@ -17,12 +17,12 @@ public class SourceSettings extends Settings {
     private String postProcessor;
     private boolean startFromBeginning;
     private final List<Setting> sourceSettings = Arrays.asList(
-            // Add all source settings here:
+            //Add all source settings here:
             new NumericSetting(PREFIX + ".task.timeout", "The max number of milliseconds the source task will use to read documents before sending them to Kafka.",
                     "Task Timeout", SettingDefaults.TASK_TIMEOUT, this::setTaskTimeout, this::getTaskTimeout),
-            new NumericSetting(PREFIX + ".task.buffer.size", "The max size the container of documents the source task will buffer before sending them to Kafka.",
+            new NumericSetting(PREFIX + ".task.buffer.size", "The max size the container of documents (in bytes) the source task will buffer before sending them to Kafka.",
                     "Task reader buffer size", SettingDefaults.TASK_BUFFER_SIZE, this::setTaskBufferSize, this::getTaskBufferSize),
-            new NumericSetting(PREFIX + ".task.batch.size","The max number of of documents the source task will buffer before sending them to Kafka.",
+            new NumericSetting(PREFIX + ".task.batch.size","The max number of documents the source task will buffer before sending them to Kafka.",
                     "Task batch size", SettingDefaults.TASK_BATCH_SIZE, this::setTaskBatchSize, this::getTaskBatchSize),
             new NumericSetting(PREFIX + ".task.poll.interval","The default polling interval in milliseconds that a source task polls for changes.",
                     "Task poll interval", SettingDefaults.TASK_POLL_INTERVAL, this::setTaskPollInterval, this::getTaskPollInterval),

--- a/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkConnectorConfigTest.java
+++ b/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkConnectorConfigTest.java
@@ -45,23 +45,4 @@ public class CosmosDBSinkConnectorConfigTest {
         assertNotNull(dbNameSetting);
         assertNull(new CosmosDBSinkConnector().config().defaultValues().get(dbNameSetting.getName()));
     }
-
-    @Test
-    public void testPresentDefaults() {
-        //The task timeout has a default setting. Let's see if the configdef does
-        assertNotNull(TIMEOUT_SETTING.getDefaultValue().get());
-        assertEquals(TIMEOUT_SETTING.getDefaultValue().get(), new CosmosDBSinkConnector().config().defaultValues().get(TIMEOUT_SETTING.getName()));
-    }
-
-    @Test
-    public void testNumericValidation() {
-        Map<String, String> settingAssignment = newMapWithMinimalSettings();
-
-        settingAssignment.put(TIMEOUT_SETTING.getName(), "definitely not a number");
-        ConfigDef config = new CosmosDBSinkConnector().config();
-
-        List<ConfigValue> postValidation = config.validate(settingAssignment);
-        ConfigValue timeoutConfigValue = postValidation.stream().filter(item -> item.name().equals(TIMEOUT_SETTING.getName())).findFirst().get();
-        assertEquals("Expected error message when assigning non-numeric value to task timeout", 1, timeoutConfigValue.errorMessages().size());
-    }
 }

--- a/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettingsTest.java
+++ b/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettingsTest.java
@@ -1,10 +1,8 @@
 package com.microsoft.azure.cosmosdb.kafka.connect.sink;
 
 import com.microsoft.azure.cosmosdb.kafka.connect.Setting;
-import com.microsoft.azure.cosmosdb.kafka.connect.SettingDefaults;
 import com.microsoft.azure.cosmosdb.kafka.connect.Settings;
 import org.apache.kafka.connect.sink.SinkTask;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -33,16 +31,13 @@ public class SinkSettingsTest {
         HashMap<String, String> source = new HashMap<>();
         //Add specific setting
         source.put(Settings.PREFIX + ".sink.post-processor", "foobar");
-        source.put(Settings.PREFIX + ".task.buffer.size", "666");
-        source.put(Settings.PREFIX + ".task.timeout", "444");
-        source.put(Settings.PREFIX + ".task.pollinginterval", "787");
+        source.put(Settings.PREFIX + ".databasename", "mydb");
         source.put(Settings.PREFIX + ".containers.topicmap", "mytopic666#mycontainer555");
         SinkSettings sinkSettings = new SinkSettings();
         sinkSettings.populate(source);
 
         assertEquals("foobar", sinkSettings.getPostProcessor());
-        assertEquals(444L, (long) sinkSettings.getTaskTimeout());
-        assertEquals(666L, (long) sinkSettings.getTaskBufferSize());
+        assertEquals("mydb", sinkSettings.getDatabaseName());
         assertEquals("mytopic666", sinkSettings.getTopicContainerMap().getTopicForContainer("mycontainer555").get());
         assertEquals("mycontainer555", sinkSettings.getTopicContainerMap().getContainerForTopic("mytopic666").get());
     }
@@ -67,36 +62,6 @@ public class SinkSettingsTest {
         SinkSettings sinkSettings = new SinkSettings();
         sinkSettings.populate(source);
         assertNull(sinkSettings.getPostProcessor());
-        assertEquals(SettingDefaults.TASK_BUFFER_SIZE, sinkSettings.getTaskBufferSize());
-        assertEquals(SettingDefaults.TASK_TIMEOUT, sinkSettings.getTaskTimeout());
-    }
-
-    @Test
-    public void testNumberVerification() {
-        HashMap<String, String> source = new HashMap<>();
-        SinkSettings sinkSettings = new SinkSettings();
-
-        source.put(Settings.PREFIX + ".task.buffer.size", "Foobar");
-        try {
-            sinkSettings.populate(source);
-            Assert.fail("Expected IllegalArgumentException");
-        } catch (Throwable t) {
-            assertEquals("Incorrect exception type: " + t.getClass().getName(), "IllegalArgumentException", t.getClass().getSimpleName());
-        }
-    }
-
-    @Test
-    public void testEmptySpaceSettings() {
-        HashMap<String, String> source = new HashMap<>();
-        SinkSettings sinkSettings = new SinkSettings();
-
-        source.put(Settings.PREFIX + ".task.buffer.size", " ");
-        try {
-            sinkSettings.populate(source);
-            Assert.fail("Expected IllegalArgumentException");
-        } catch (Throwable t) {
-            assertEquals("Incorrect exception type: " + t.getClass().getName(), "IllegalArgumentException", t.getClass().getSimpleName());
-        }
     }
 
 }

--- a/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettingsTest.java
+++ b/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettingsTest.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.cosmosdb.kafka.connect.source;
 
 import com.microsoft.azure.cosmosdb.kafka.connect.Settings;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -57,5 +58,33 @@ public class SourceSettingsTest {
         sourceSettings.setContainerList("");
         assertEquals("",  sourceSettings.getContainerList());
 
+    }
+
+    @Test
+    public void testNumberVerification() {
+        HashMap<String, String> source = new HashMap<>();
+        SourceSettings sourceSettings = new SourceSettings();
+
+        source.put(Settings.PREFIX + ".task.buffer.size", "Foobar");
+        try {
+            sourceSettings.populate(source);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (Throwable t) {
+            assertEquals("Incorrect exception type: " + t.getClass().getName(), "IllegalArgumentException", t.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    public void testEmptySpaceSettings() {
+        HashMap<String, String> source = new HashMap<>();
+        SourceSettings sourceSettings = new SourceSettings();
+
+        source.put(Settings.PREFIX + ".task.buffer.size", " ");
+        try {
+            sourceSettings.populate(source);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (Throwable t) {
+            assertEquals("Incorrect exception type: " + t.getClass().getName(), "IllegalArgumentException", t.getClass().getSimpleName());
+        }
     }
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Ensuring that sink config settings only show up when setting up the sink connector (vice versa for source connector)
  - Settings common for both sink and source will show up when setting up either connector
- Some wording changes for setting descriptions
- Minor code style changes

## Issues Closed or Referenced

- Closes #174 