### PR TITLE
Exposed upsert configuration for Sink Connector and added user-agent to cosmosdb java client

### DIFF
--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/SettingDefaults.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/SettingDefaults.java
@@ -8,4 +8,5 @@ public class SettingDefaults {
     public static final Long TASK_BUFFER_SIZE=10000L;
     public static final Long TASK_BATCH_SIZE = 100L;
     public static final Long TASK_POLL_INTERVAL = 1000L;
+    public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
 }

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettingDefaults.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettingDefaults.java
@@ -1,0 +1,5 @@
+package com.microsoft.azure.cosmosdb.kafka.connect.sink;
+
+public class SinkSettingDefaults {
+    public static final Boolean USE_UPSERT = false;
+}

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/SinkSettings.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.cosmosdb.kafka.connect.sink;
 
 import com.microsoft.azure.cosmosdb.kafka.connect.Setting;
+import com.microsoft.azure.cosmosdb.kafka.connect.BooleanSetting;
 import com.microsoft.azure.cosmosdb.kafka.connect.Settings;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.kafka.connect.sink.SinkTask;
@@ -13,6 +14,7 @@ import java.util.List;
  */
 public class SinkSettings extends Settings {
     private String postProcessor;
+    private Boolean useUpsert;
     private final List<Setting> sinkSettings = Arrays.asList(
             //Add all sink settings here:
             new Setting(SinkTask.TOPICS_CONFIG, "List of topics to consume, separated by commas.", "Topics", s -> {
@@ -22,11 +24,32 @@ public class SinkSettings extends Settings {
                             "Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. " +
                             "Only one of " + SinkTask.TOPICS_CONFIG + " or " + SinkTask.TOPICS_REGEX_CONFIG + " should be specified.",
                     "Topics RegEx", s -> {
-            }, () -> "")
+            }, () -> ""),
+            new BooleanSetting(Settings.PREFIX + ".sink.useUpsert", "Behaviour of operation to Cosmos DB. " +
+                    "'false' is the default value and signals that all operations to Cosmos DB are Insert; 'true' changes the behaviour to use Upsert operation.",
+                    "Use Upsert", SinkSettingDefaults.USE_UPSERT, this::setUseUpsert, this::getUseUpsert)
     );
 
     @Override
     protected List<Setting> getAllSettings() {
         return ListUtils.union(super.getAllSettings(), sinkSettings);
+    }
+
+    /**
+     * Returns boolean value to use upsert operation
+     *
+     * @return useUpsert
+     */
+    public Boolean getUseUpsert() {
+        return this.useUpsert;
+    }
+
+    /**
+     * Sets boolean value to use upsert operation
+     *
+     * @param useUpsert
+     */
+    public void setUseUpsert(Boolean useUpsert) {
+        this.useUpsert = useUpsert;
     }
 }

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.cosmosdb.kafka.connect.source;
 
+import com.microsoft.azure.cosmosdb.kafka.connect.SettingDefaults;
 import com.azure.cosmos.*;
 import com.azure.cosmos.models.*;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -147,6 +148,7 @@ public class CosmosDBSourceTask extends SourceTask {
                 .key(this.settings.getKey())
                 .consistencyLevel(ConsistencyLevel.SESSION)
                 .contentResponseOnWriteEnabled(true)
+                .userAgentSuffix(SettingDefaults.COSMOS_CLIENT_USER_AGENT_SUFFIX+version())
                 .buildAsyncClient();
     }
 

--- a/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkTaskTest.java
+++ b/src/test/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkTaskTest.java
@@ -30,6 +30,7 @@ public class CosmosDBSinkTaskTest {
     private final String topicName = "testtopic";
     private final String containerName = "container666";
     private final String databaseName = "fakeDatabase312";
+    private final Boolean upsertFalse = false;
     private CosmosDBSinkTask testTask;
     private CosmosClient mockCosmosClient;
     private CosmosContainer mockContainer;
@@ -42,6 +43,7 @@ public class CosmosDBSinkTaskTest {
         SinkSettings settings = new SinkSettings();
         settings.setTopicContainerMap(TopicContainerMap.deserialize(topicName + "#" + containerName));
         settings.setDatabaseName(databaseName);
+        settings.setUseUpsert(upsertFalse);
         FieldUtils.writeField(testTask, "settings", settings, true);
 
         //Mock the Cosmos SDK


### PR DESCRIPTION


## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Exposed use upsert config to Sink Connector Property to support both Insert and Upsert Operations
- Set default value to false for upsert config
- Set User-Agent for CosmosDB Java client

## Review notes
![image](https://user-images.githubusercontent.com/71272427/102287593-63b09980-3f00-11eb-93f1-4b1a80625d9d.png)

## Issues Closed or Referenced

- Closes #147 #167 
