### PR TITLE
Using customer dockerfile instead of volume mounts

### DIFF
--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -98,7 +98,8 @@ services:
       - rest-proxy
 
   connect:
-    image: confluentinc/cp-kafka-connect:6.0.0
+    # Using modified version of confluentinc/cp-kafka-connect:6.0.0 to avoid dealing with volume mounts
+    image: cosmosdb-kafka-connect:latest
     hostname: connect
     container_name: connect
     ports:
@@ -128,8 +129,6 @@ services:
       CONNECT_LOG4J_ROOT_LOGLEVEL: "WARN"
       CONNECT_LOG4J_LOGGERS: "org.apache.kafka=INFO,org.reflections=ERROR,com.microsoft=DEBUG"
       CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/jars'
-    volumes:
-      - ./connectors:/etc/kafka-connect/jars/
     depends_on:
       - zookeeper
       - broker

--- a/src/docker/startup.ps1
+++ b/src/docker/startup.ps1
@@ -22,5 +22,8 @@ copy target\*.jar $PSScriptRoot/connectors
 rm -rf "$PSScriptRoot/connectors/insertuuid"
 cd $PSScriptRoot
 
+Write-Host "Building Cosmos DB Kafka Connect Docker image"
+docker build . -t cosmosdb-kafka-connect:latest
+
 Write-Host "Starting Docker Compose..."
 docker-compose up -d

--- a/src/docker/startup.sh
+++ b/src/docker/startup.sh
@@ -20,5 +20,8 @@ cp target/*.jar ../
 cd .. && rm -rf insertuuid
 cd ../
 
+echo "Building Cosmos DB Kafka Connect Docker image"
+docker build . -t cosmosdb-kafka-connect:latest
+
 echo "Starting Docker Compose..."
 docker-compose up -d

--- a/src/integration-test/Dockerfile
+++ b/src/integration-test/Dockerfile
@@ -1,0 +1,4 @@
+# Build the Cosmos DB Connectors on top of the Kafka Connect image
+FROM confluentinc/cp-kafka-connect:6.0.0
+
+COPY connectors/ /etc/kafka-connect/jars


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Remove mounting the custom jars as volume mounts in the Kafka Connect docker container
Use custom docker file to copy the jars into the docker image instead

## Issues Closed or Referenced

- Closes #182 