### PR TITLE
Added support for avro and json schema converters for Sink Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <name>Confluent</name>
+            <url>http://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -38,9 +46,13 @@
             <artifactId>azure-cosmos</artifactId>
             <version>4.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-maven-plugin</artifactId>
+            <version>6.0.1</version>
+        </dependency>
 
         <!-- Apache commons -->
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <kafka.version>2.6.0</kafka.version>
+        <kafka.version>2.7.0</kafka.version>
         <log4j.version>2.14.0</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/CosmosDBSinkTask.java
@@ -49,7 +49,6 @@ public class CosmosDBSinkTask extends SinkTask {
         client.createDatabaseIfNotExists(settings.getDatabaseName());
     }
 
-
     @Override
     public void put(Collection<SinkRecord> records) {
         if (CollectionUtils.isEmpty(records)) {
@@ -60,12 +59,11 @@ public class CosmosDBSinkTask extends SinkTask {
         logger.info("Sending {} records to be written", records.size());
 
         Map<String, List<SinkRecord>> recordsByContainer = records.stream()
-                //Find target collection for each record
-                .collect(Collectors.groupingBy(record ->
-                        settings.getTopicContainerMap().getContainerForTopic(record.topic()).orElseThrow(
-                                () -> new IllegalStateException(String.format("No container defined for topic %s .",
-                                record.topic())))));
-                                
+                // Find target collection for each record
+                .collect(Collectors.groupingBy(record -> settings.getTopicContainerMap()
+                        .getContainerForTopic(record.topic()).orElseThrow(() -> new IllegalStateException(
+                                String.format("No container defined for topic %s .", record.topic())))));
+
         for (Map.Entry<String, List<SinkRecord>> entry : recordsByContainer.entrySet()) {
             String containerName = entry.getKey();
             CosmosContainer container = client.getDatabase(settings.getDatabaseName()).getContainer(containerName);
@@ -73,23 +71,22 @@ public class CosmosDBSinkTask extends SinkTask {
                 logger.debug("Writing record, value type: {}", record.value().getClass().getName());
                 logger.debug("Key Schema: {}", record.keySchema());
                 logger.debug("Value schema: {}", record.valueSchema());
-                logger.debug("Value.toString(): {}",  record.value() != null ? record.value().toString() : "<null>");
-                
+                logger.debug("Value.toString(): {}", record.value() != null ? record.value().toString() : "<null>");
+
                 Object recordValue;
-                if(record.value() instanceof Struct) {
+                if (record.value() instanceof Struct) {
                     Map<String, Object> jsonMap = StructToJsonMap.toJsonMap((Struct) record.value());
                     recordValue = mapper.convertValue(jsonMap, JsonNode.class);
-                }
-                else {
+                } else {
                     recordValue = record.value();
                 }
 
                 try {
                     if (Boolean.TRUE.equals(this.settings.getUseUpsert())) {
-                        container.upsertItem(recordValue); 
-                      } else {
+                        container.upsertItem(recordValue);
+                    } else {
                         container.createItem(recordValue);
-                      }
+                    }
                 } catch (BadRequestException bre) {
                     throw new CosmosDBWriteException(record, bre);
                 }

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/StructToJsonMap.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/StructToJsonMap.java
@@ -1,0 +1,64 @@
+package com.microsoft.azure.cosmosdb.kafka.connect.sink;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+public class StructToJsonMap {
+
+    public static Map<String, Object> toJsonMap(Struct struct) {
+        Map<String, Object> jsonMap = new HashMap<String, Object>(0);
+        List<Field> fields = struct.schema().fields();
+        for (Field field : fields) {
+            String fieldName = field.name();
+            Schema.Type fieldType = field.schema().type();
+            String schemaName=field.schema().name();
+            switch (fieldType) {
+                case STRING:
+                    jsonMap.put(fieldName, struct.getString(fieldName));
+                    break;
+                case INT32:
+                	if (Date.LOGICAL_NAME.equals(schemaName) 
+                			|| Time.LOGICAL_NAME.equals(schemaName)) {
+                		jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
+                	} else {
+                		jsonMap.put(fieldName, struct.getInt32(fieldName));
+                	}
+                    break;
+                case INT16:
+                    jsonMap.put(fieldName, struct.getInt16(fieldName));
+                    break;
+                case INT64:
+                	if (Timestamp.LOGICAL_NAME.equals(schemaName)) {
+                		jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
+                	} else {
+                		jsonMap.put(fieldName, struct.getInt64(fieldName));
+                	}
+                    break;
+                case FLOAT32:
+                    jsonMap.put(fieldName, struct.getFloat32(fieldName));
+                    break;
+                case FLOAT64:
+                    jsonMap.put(fieldName, struct.getFloat64(fieldName));
+                    break;
+                case BOOLEAN:
+                    jsonMap.put(fieldName, struct.getBoolean(fieldName));
+                    break;
+                case STRUCT:
+                    jsonMap.put(fieldName, toJsonMap(struct.getStruct(fieldName)));
+                    break;
+                default:
+                    jsonMap.put(fieldName, struct.get(fieldName));
+                    break;
+            }
+        }
+        return jsonMap;
+    }
+}

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/StructToJsonMap.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/sink/StructToJsonMap.java
@@ -19,28 +19,27 @@ public class StructToJsonMap {
         for (Field field : fields) {
             String fieldName = field.name();
             Schema.Type fieldType = field.schema().type();
-            String schemaName=field.schema().name();
+            String schemaName = field.schema().name();
             switch (fieldType) {
                 case STRING:
                     jsonMap.put(fieldName, struct.getString(fieldName));
                     break;
                 case INT32:
-                	if (Date.LOGICAL_NAME.equals(schemaName) 
-                			|| Time.LOGICAL_NAME.equals(schemaName)) {
-                		jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
-                	} else {
-                		jsonMap.put(fieldName, struct.getInt32(fieldName));
-                	}
+                    if (Date.LOGICAL_NAME.equals(schemaName) || Time.LOGICAL_NAME.equals(schemaName)) {
+                        jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
+                    } else {
+                        jsonMap.put(fieldName, struct.getInt32(fieldName));
+                    }
                     break;
                 case INT16:
                     jsonMap.put(fieldName, struct.getInt16(fieldName));
                     break;
                 case INT64:
-                	if (Timestamp.LOGICAL_NAME.equals(schemaName)) {
-                		jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
-                	} else {
-                		jsonMap.put(fieldName, struct.getInt64(fieldName));
-                	}
+                    if (Timestamp.LOGICAL_NAME.equals(schemaName)) {
+                        jsonMap.put(fieldName, (java.util.Date) struct.get(fieldName));
+                    } else {
+                        jsonMap.put(fieldName, struct.getInt64(fieldName));
+                    }
                     break;
                 case FLOAT32:
                     jsonMap.put(fieldName, struct.getFloat32(fieldName));

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/CosmosDBSourceTask.java
@@ -8,6 +8,7 @@ import com.microsoft.azure.cosmosdb.kafka.connect.TopicContainerMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.scheduler.Schedulers;
@@ -30,6 +31,7 @@ public class CosmosDBSourceTask extends SourceTask {
     private SourceSettings settings = null;
     private LinkedTransferQueue<JsonNode> queue = null;
     private ChangeFeedProcessor changeFeedProcessor;
+    private JsonToStruct jsonToStruct = new JsonToStruct();
 
     @Override
     public String version() {
@@ -104,29 +106,38 @@ public class CosmosDBSourceTask extends SourceTask {
         while ( bufferSize > 0 && count < batchSize && System.currentTimeMillis() < maxWaitTime ) {
             JsonNode node = this.queue.poll(this.settings.getTaskPollInterval(), TimeUnit.MILLISECONDS);
 
-            if(node != null) {                   
-                // Set the Kafka message key if option is enabled and field is configured in document
-                String messageKey = "";
-                if (this.settings.isMessageKeyEnabled()) {
-                    JsonNode messageKeyFieldNode = node.get(this.settings.getMessageKeyField());
-                    messageKey = (messageKeyFieldNode != null) ? messageKeyFieldNode.toString() : "";
-                }
-                
-                // Since Lease container takes care of maintaining state we don't have to send source offset to kafka
-                SourceRecord sourceRecord = new SourceRecord(partition, null, topic,
-                                                    Schema.STRING_SCHEMA, messageKey, 
-                                                    Schema.STRING_SCHEMA, node.toString());
+            if(node != null) {
+                try {                
+                    // Set the Kafka message key if option is enabled and field is configured in document
+                    String messageKey = "";
+                    if (this.settings.isMessageKeyEnabled()) {
+                        JsonNode messageKeyFieldNode = node.get(this.settings.getMessageKeyField());
+                        messageKey = (messageKeyFieldNode != null) ? messageKeyFieldNode.toString() : "";
+                    }
 
-                bufferSize -= sourceRecord.value().toString().getBytes().length;
+                    // Convert JSON to Kafka Connect struct and JSON schema
+                    SchemaAndValue schemaAndValue = jsonToStruct.recordToSchemaAndValue(node);
 
-                // If the buffer Size exceeds then do not remove the node .
-                if (bufferSize <=0){
-                    this.queue.add(node);
-                    break;
+                    // Since Lease container takes care of maintaining state we don't have to send source offset to kafka
+                    SourceRecord sourceRecord = new SourceRecord(partition, null, topic,
+                                                        Schema.STRING_SCHEMA, messageKey,
+                                                        schemaAndValue.schema(), schemaAndValue.value());
+
+                    bufferSize -= sourceRecord.value().toString().getBytes().length;
+
+                    // If the buffer Size exceeds then do not remove the node .
+                    if (bufferSize <=0){
+                        this.queue.add(node);
+                        break;
+                    }
+                    
+                    records.add(sourceRecord);
+                    count++;
                 }
-                
-                records.add(sourceRecord);
-                count++;
+                catch (Exception e) {
+                    logger.error("Failed to fill Source Records for Topic {}", topic);
+                    throw e;
+                }
             }
         }
     }

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
@@ -28,25 +28,22 @@ public class JsonToStruct {
     public SchemaAndValue recordToSchemaAndValue(final JsonNode node) {
         Schema nodeSchema = inferSchema(node);
         Struct struct = new Struct(nodeSchema);
-                
-        nodeSchema
-            .fields()  
-            .forEach(
-                field -> {
-                    JsonNode fieldValue = node.get(field.name());
-                    if (fieldValue != null) {
-                        SchemaAndValue schemaAndValue = toSchemaAndValue(field.schema(), fieldValue);
-                        struct.put(field, schemaAndValue.value());
-                    } else {
-                        boolean optionalField = field.schema().isOptional();
-                        Object defaultValue = field.schema().defaultValue();
-                        if (optionalField || defaultValue != null) {
-                        struct.put(field, defaultValue);
-                        } else {
-                            logger.error("Missing value for field {}", field.name());
-                        }
-                    }
-                });
+
+        nodeSchema.fields().forEach(field -> {
+            JsonNode fieldValue = node.get(field.name());
+            if (fieldValue != null) {
+                SchemaAndValue schemaAndValue = toSchemaAndValue(field.schema(), fieldValue);
+                struct.put(field, schemaAndValue.value());
+            } else {
+                boolean optionalField = field.schema().isOptional();
+                Object defaultValue = field.schema().defaultValue();
+                if (optionalField || defaultValue != null) {
+                    struct.put(field, defaultValue);
+                } else {
+                    logger.error("Missing value for field {}", field.name());
+                }
+            }
+        });
         return new SchemaAndValue(nodeSchema, struct);
     }
 
@@ -59,12 +56,13 @@ public class JsonToStruct {
             case NUMBER:
                 if (jsonValue.isIntegralNumber()) {
                     return Schema.INT64_SCHEMA;
-                }
-                else {
+                } else {
                     return Schema.FLOAT64_SCHEMA;
                 }
             case ARRAY:
-                SchemaBuilder arrayBuilder = SchemaBuilder.array(jsonValue.elements().hasNext() ? inferSchema(jsonValue.elements().next()) : Schema.OPTIONAL_STRING_SCHEMA);
+                SchemaBuilder arrayBuilder = SchemaBuilder
+                        .array(jsonValue.elements().hasNext() ? inferSchema(jsonValue.elements().next())
+                                : Schema.OPTIONAL_STRING_SCHEMA);
                 arrayBuilder.name(generateName(arrayBuilder));
                 return arrayBuilder.build();
             case OBJECT:
@@ -88,80 +86,80 @@ public class JsonToStruct {
 
     // Generate Unique Schema Name
     public static String generateName(final SchemaBuilder builder) {
-      return format(SCHEMA_NAME_TEMPLATE, Objects.hashCode(builder.build())).replace("-", "_");
+        return format(SCHEMA_NAME_TEMPLATE, Objects.hashCode(builder.build())).replace("-", "_");
     }
 
     private SchemaAndValue toSchemaAndValue(final Schema schema, final JsonNode node) {
         SchemaAndValue schemaAndValue = new SchemaAndValue(schema, node);
         if (schema.isOptional() && node.isNull()) {
             return new SchemaAndValue(schema, null);
-          }
-          switch (schema.type()) {
+        }
+        switch (schema.type()) {
             case INT8:
             case INT16:
             case INT32:
             case INT64:
             case FLOAT32:
             case FLOAT64:
-              schemaAndValue = numberToSchemaAndValue(schema, node);
-              break;
+                schemaAndValue = numberToSchemaAndValue(schema, node);
+                break;
             case BOOLEAN:
-              schemaAndValue = new SchemaAndValue(schema, node.asBoolean());
-              break;
+                schemaAndValue = new SchemaAndValue(schema, node.asBoolean());
+                break;
             case STRING:
-              schemaAndValue = new SchemaAndValue(schema, node.asText());
-              break;
+                schemaAndValue = new SchemaAndValue(schema, node.asText());
+                break;
             case BYTES:
-              schemaAndValue = new SchemaAndValue(schema, node);
-              break;
+                schemaAndValue = new SchemaAndValue(schema, node);
+                break;
             case ARRAY:
-              schemaAndValue = new SchemaAndValue(schema, node);
-              break;
+                schemaAndValue = new SchemaAndValue(schema, node);
+                break;
             case MAP:
-              schemaAndValue = new SchemaAndValue(schema, node);
-              break;
+                schemaAndValue = new SchemaAndValue(schema, node);
+                break;
             case STRUCT:
-              schemaAndValue = recordToSchemaAndValue(node);
-              break;
+                schemaAndValue = recordToSchemaAndValue(node);
+                break;
             default:
-              logger.error("Unsupported Schema type: %s", schema.type());
-          }
-          return schemaAndValue;
+                logger.error("Unsupported Schema type: %s", schema.type());
+        }
+        return schemaAndValue;
     }
 
     private SchemaAndValue numberToSchemaAndValue(final Schema schema, final JsonNode nodeValue) {
         Object value = null;
         if (nodeValue.isNumber()) {
-          if (nodeValue.isInt()) {
-            value = nodeValue.intValue();
-          } else if (nodeValue.isDouble()) {
-            value = nodeValue.doubleValue();
-          }
+            if (nodeValue.isInt()) {
+                value = nodeValue.intValue();
+            } else if (nodeValue.isDouble()) {
+                value = nodeValue.doubleValue();
+            }
         } else {
-          logger.error("Unexpted value %s for Schma %s", nodeValue, schema.type());
+            logger.error("Unexpted value %s for Schma %s", nodeValue, schema.type());
         }
-    
+
         switch (schema.type()) {
-          case INT8:
-            value = convertToByte(schema, value);
-            break;
-          case INT16:
-            value = convertToShort(schema, value);
-            break;
-          case INT32:
-            value = convertToInteger(schema, value);
-            break;
-          case INT64:
-            value = convertToLong(schema, value);
-            break;
-          case FLOAT32:
-            value = convertToFloat(schema, value);
-            break;
-          case FLOAT64:
-            value = convertToDouble(schema, value);
-            break;
-          default:
-            logger.error("Unsupported Schema type: %s", schema.type());
+            case INT8:
+                value = convertToByte(schema, value);
+                break;
+            case INT16:
+                value = convertToShort(schema, value);
+                break;
+            case INT32:
+                value = convertToInteger(schema, value);
+                break;
+            case INT64:
+                value = convertToLong(schema, value);
+                break;
+            case FLOAT32:
+                value = convertToFloat(schema, value);
+                break;
+            case FLOAT64:
+                value = convertToDouble(schema, value);
+                break;
+            default:
+                logger.error("Unsupported Schema type: %s", schema.type());
         }
         return new SchemaAndValue(schema, value);
     }

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
@@ -1,0 +1,160 @@
+package com.microsoft.azure.cosmosdb.kafka.connect.source;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.kafka.connect.data.Values.convertToByte;
+import static org.apache.kafka.connect.data.Values.convertToDouble;
+import static org.apache.kafka.connect.data.Values.convertToFloat;
+import static org.apache.kafka.connect.data.Values.convertToInteger;
+import static org.apache.kafka.connect.data.Values.convertToLong;
+import static org.apache.kafka.connect.data.Values.convertToShort;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class JsonToStruct {
+    private static final Logger logger = LoggerFactory.getLogger(CosmosDBSourceTask.class);
+
+    public SchemaAndValue recordToSchemaAndValue(final JsonNode node) {
+        Schema nodeSchema = inferSchema(node);
+        Struct struct = new Struct(nodeSchema);
+                
+        nodeSchema
+            .fields()  
+            .forEach(
+                field -> {
+                    JsonNode fieldValue = node.get(field.name());
+                    if (fieldValue != null) {
+                        SchemaAndValue schemaAndValue = toSchemaAndValue(field.schema(), fieldValue);
+                        struct.put(field, schemaAndValue.value());
+                    } else {
+                        boolean optionalField = field.schema().isOptional();
+                        Object defaultValue = field.schema().defaultValue();
+                        if (optionalField || defaultValue != null) {
+                        struct.put(field, defaultValue);
+                        } else {
+                            logger.error("msg");
+                        }
+                    }
+                });
+        return new SchemaAndValue(nodeSchema, struct);
+    }
+
+    private Schema inferSchema(JsonNode jsonValue) {
+        switch (jsonValue.getNodeType()) {
+            case NULL:
+                return Schema.OPTIONAL_STRING_SCHEMA;
+            case BOOLEAN:
+                return Schema.BOOLEAN_SCHEMA;
+            case NUMBER:
+                if (jsonValue.isIntegralNumber()) {
+                    // Add support for INT8 & INT64
+                    return Schema.INT32_SCHEMA;
+                }
+                else {
+                    return Schema.FLOAT64_SCHEMA;
+                }
+            case ARRAY:
+                SchemaBuilder arrayBuilder = SchemaBuilder.array(jsonValue.elements().hasNext() ? inferSchema(jsonValue.elements().next()) : Schema.OPTIONAL_STRING_SCHEMA);
+                return arrayBuilder.build();
+            case OBJECT:
+                SchemaBuilder structBuilder = SchemaBuilder.struct();
+                Iterator<Map.Entry<String, JsonNode>> it = jsonValue.fields();
+                while (it.hasNext()) {
+                    Map.Entry<String, JsonNode> entry = it.next();
+                    structBuilder.field(entry.getKey(), inferSchema(entry.getValue()));
+                }
+                return structBuilder.build();
+            case STRING:
+                return Schema.STRING_SCHEMA;
+            case BINARY:
+            case MISSING:
+            case POJO:
+            default:
+                return null;
+        }
+    }
+
+    private SchemaAndValue toSchemaAndValue(final Schema schema, final JsonNode node) {
+        SchemaAndValue schemaAndValue = new SchemaAndValue(schema, node);
+        if (schema.isOptional() && node.isNull()) {
+            return new SchemaAndValue(schema, null);
+          }
+          switch (schema.type()) {
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case FLOAT32:
+            case FLOAT64:
+              schemaAndValue = numberToSchemaAndValue(schema, node);
+              break;
+            case BOOLEAN:
+              schemaAndValue = new SchemaAndValue(schema, node.asBoolean());
+              break;
+            case STRING:
+              schemaAndValue = new SchemaAndValue(schema, node.asText());
+              break;
+            case BYTES:
+              schemaAndValue = new SchemaAndValue(schema, node);
+              break;
+            case ARRAY:
+              schemaAndValue = new SchemaAndValue(schema, node);
+              break;
+            case MAP:
+              schemaAndValue = new SchemaAndValue(schema, node);
+              break;
+            case STRUCT:
+              schemaAndValue = recordToSchemaAndValue(node);
+              break;
+            default:
+              logger.error("Unsupported Schema type: %s", schema.type());
+          }
+          return schemaAndValue;
+    }
+
+    private SchemaAndValue numberToSchemaAndValue(final Schema schema, final JsonNode nodeValue) {
+        Object value = null;
+        if (nodeValue.isNumber()) {
+          if (nodeValue.isInt()) {
+            value = nodeValue.intValue();
+          } else if (nodeValue.isDouble()) {
+            value = nodeValue.doubleValue();
+          }
+        } else {
+          logger.error("Unexpted value %s for Schma %s", nodeValue, schema.type());
+        }
+    
+        switch (schema.type()) {
+          case INT8:
+            value = convertToByte(schema, value);
+            break;
+          case INT16:
+            value = convertToShort(schema, value);
+            break;
+          case INT32:
+            value = convertToInteger(schema, value);
+            break;
+          case INT64:
+            value = convertToLong(schema, value);
+            break;
+          case FLOAT32:
+            value = convertToFloat(schema, value);
+            break;
+          case FLOAT64:
+            value = convertToDouble(schema, value);
+            break;
+          default:
+            logger.error("Unsupported Schema type: %s", schema.type());
+        }
+        return new SchemaAndValue(schema, value);
+    }
+
+}

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/JsonToStruct.java
@@ -40,7 +40,7 @@ public class JsonToStruct {
                         if (optionalField || defaultValue != null) {
                         struct.put(field, defaultValue);
                         } else {
-                            logger.error("msg");
+                            logger.error("Missing value for field {}", field.name());
                         }
                     }
                 });
@@ -56,7 +56,7 @@ public class JsonToStruct {
             case NUMBER:
                 if (jsonValue.isIntegralNumber()) {
                     // Add support for INT8 & INT64
-                    return Schema.INT32_SCHEMA;
+                    return Schema.INT64_SCHEMA;
                 }
                 else {
                     return Schema.FLOAT64_SCHEMA;

--- a/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/kafka/connect/source/SourceSettings.java
@@ -41,7 +41,6 @@ public class SourceSettings extends Settings {
                     "Change Feed start from beginning", SourceSettingDefaults.CHANGE_FEED_START_FROM_BEGINNING, this::setStartFromBeginning, this::isStartFromBeginning)
     );
 
-
     private String workerName;
 
     public void setWorkerName(String workerName) {


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Convert kafka stored struct back to JSON to store sink record successfully in CosmosDB
- Added supported for `io.confluent.connect.avro.AvroConverter` and `org.apache.kafka.connect.json.JsonConverter` with Schema

## Observability + Testing
- What changes or considerations did you make in relation to observability?
   - Added loggers

- Did you add testing to account for any new or changed work?
   - Added notes to follow up on additional unit/integration testing with mentioned converters

## Review notes
- Should be merged after this PR: #217
- Validate Sink Connector with below configurations:
   - Validate JSON Converter with below values enabled.
      >"key.converter.schemas.enable": "true"
      >"value.converter.schemas.enable": "true"
      >"key.converter.class": "org.apache.kafka.connect.json.JsonConverter"
      >"value.converter.class": "org.apache.kafka.connect.json.JsonConverter"
   - Validate io.confluent.connect.avro.AvroConverter by seeting below values
      >"key.converter.class": "io.confluent.connect.avro.AvroConverter"
      >"value.converter": "io.confluent.connect.avro.AvroConverter"
      >"key.converter.schema.registry.url": "http://schema-registry:8081"
      >"value.converter.schema.registry.url": "http://schema-registry:8081"
      >"key.converter.schemas.enable": "true"
      >"value.converter.schemas.enable": "true"

## Issues Closed or Referenced

- Closes #193 
- References #12 #217 (this references the issue but does not close with PR)
