### PR TITLE
adding a sprint tracker issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_tracker.md
+++ b/.github/ISSUE_TEMPLATE/sprint_tracker.md
@@ -1,0 +1,37 @@
+---
+name: Sprint Tracker
+about: Used to track adjustments to sprint
+title: ''
+labels: ''
+assignees: ''
+
+---
+- - - -
+**## Sprint Goal**
+_Put a concise sprint goal here to keep your team focused througout sprint._
+- - - -
+
+**## Commitment**
+- [ ] Bucket _example: performance improvements, migrate data to x, etc_
+  - #
+
+* * * * 
+**## Sprint Adjustments**
+* * * *
+
+**## Added to Sprint**
+_Ensure you list the justification for pulling anything into sprint. Ex: Prod outage, revenue impacts, dev bandwidth, etc.__
+- [ ] #
+    - Justification:
+
+**## Trade-offs**
+_If you're swapping tickets in, what tickets are falling out?__
+- #
+
+**## Notes**
+
+
+- - - -
+## Completion Rate
+- - - -
+# %


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [x] GitHub Template changes

## Purpose of PR
Add a template for sprint tracking issue type so we can better keep track of sprint adjustments

## Review notes
I am testing moving our notes for sprint tracking to an issue because I'm running out of characters: (
