### PR TITLE
adding labels to the sprint tracker template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_tracker.md
+++ b/.github/ISSUE_TEMPLATE/sprint_tracker.md
@@ -2,7 +2,7 @@
 name: Sprint Tracker
 about: Used to track adjustments to sprint
 title: ''
-labels: ''
+labels: 'internal, sharing, refine, tracker'
 assignees: ''
 
 ---
@@ -21,7 +21,7 @@ _Put a concise sprint goal here to keep your team focused throughout sprint._
 ### Added to Sprint
 _Ensure you list the justification for pulling anything into sprint. Ex: Prod outage, revenue impacts, dev bandwidth, etc._
 - [ ] # (issue number)
-    - Justification:
+    - **Justification:**
 
 ### Trade-offs
 _If you're swapping tickets in, what tickets are falling out?_


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [x] GitHub Template changes

## Purpose of PR
Add the right labels when someone creates a sprint tracker issue type
