### PR TITLE
Removing unneeded source configs

### DIFF
--- a/doc/README_Source.md
+++ b/doc/README_Source.md
@@ -73,7 +73,6 @@ Refer to the [source properties](#source-configuration-properties) section for m
     "connect.cosmosdb.master.key": "<cosmosdbprimarykey>",
     "connect.cosmosdb.databasename": "kafkaconnect",
     "connect.cosmosdb.containers.topicmap": "apparels#kafka",
-    "connect.cosmosdb.containers": "kafka",
     "connect.cosmosdb.offset.useLatest": false,
     "value.converter.schemas.enable": "false",
     "key.converter.schemas.enable": "false"
@@ -173,7 +172,6 @@ The following settings are used to configure the Cosmos DB Kafka Source Connecto
 | connect.cosmosdb.master.key | string | the configured master key for Cosmos DB | Required |
 | connect.cosmosdb.connection.endpoint | uri | the endpoint for the Cosmos DB Account | Required |
 | connect.cosmosdb.containers.topicmap | string | comma separeted topic to collection mapping, eg. topic1#coll1,topic2#coll2 | Required |
-| connect.cosmosdb.containers | string | list of collections to monitor |  Required |
 | connect.cosmosdb.messagekey.enabled | boolean | set if the Kafka message key should be set. Default is `true` | Required |
 | connect.cosmosdb.messagekey.field | string | use the field's value from the document as the message key. Default is `id` | Required |
 | connect.cosmosdb.offset.useLatest | boolean |  Set to `"true"` to use the latest (most recent) source offset, `"false"` to use the earliest recorded offset. Default is `false` | Required |

--- a/src/docker/resources/source.example.json
+++ b/src/docker/resources/source.example.json
@@ -9,7 +9,6 @@
     "key.converter.schemas.enable": "false",
     "connect.cosmosdb.task.poll.interval": "1000",
     "connect.cosmosdb.offset.useLatest": false,
-    "connect.cosmosdb.containers": "kafka",
     "connect.cosmosdb.connection.endpoint": "https://<cosmosinstance-name>.documents.azure.com:443/",
     "connect.cosmosdb.master.key": "<cosmosdbprimarykey>",
     "connect.cosmosdb.databasename": "kafkaconnect",

--- a/src/docker/resources/source.example.properties
+++ b/src/docker/resources/source.example.properties
@@ -4,7 +4,6 @@ tasks.max=1
 format=json
 connect.cosmosdb.task.poll.interval=1000
 connect.cosmosdb.offset.useLatest=false
-connect.cosmosdb.containers=kafka
 connect.cosmosdb.connection.endpoint=https://<cosmosinstance-name>.documents.azure.com:443/
 connect.cosmosdb.master.key=<cosmosdbprimarykey>
 connect.cosmosdb.databasename=kafkaconnect

--- a/src/main/java/com/azure/cosmos/kafka/connect/TopicContainerMap.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/TopicContainerMap.java
@@ -5,7 +5,9 @@ import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -78,6 +80,10 @@ public class TopicContainerMap {
 
     public Optional<String> getTopicForContainer(String containerName) {
         return Optional.ofNullable(map.inverseBidiMap().get(containerName));
+    }
+
+    public List<String> getContainerList() {
+        return new ArrayList<String>(map.values());
     }
 
 }

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
@@ -41,21 +41,6 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         "The polling interval in milliseconds that a source task polls for changes.";
     private static final String COSMOS_SOURCE_TASK_POLL_INTERVAL_DISPLAY = "Task poll interval";
 
-    static final String COSMOS_CONTAINERS_LIST_CONF = "connect.cosmosdb.containers";
-    private static final String COSMOS_CONTAINERS_LIST_DOC = 
-        "A comma delimited list of source Cosmos DB container names.";
-    private static final String COSMOS_CONTAINERS_LIST_DISPLAY = "Cosmos Container Names List";
-
-    static final String COSMOS_ASSIGNED_CONTAINER_CONF = "connect.cosmosdb.assigned.container";
-    private static final String COSMOS_ASSIGNED_CONTAINER_DOC = 
-        "The Cosmos DB Feed Container assigned to the task.";
-    private static final String COSMOS_ASSIGNED_CONTAINER_DISPLAY = "Cosmos Assigned Container";
-
-    static final String COSMOS_WORKER_NAME_CONF = "connect.cosmosdb.worker.name";
-    private static final String COSMOS_WORKER_NAME_DEFAULT = "worker";
-    private static final String COSMOS_WORKER_NAME_DOC = "The Cosmos DB worker name";
-    private static final String COSMOS_WORKER_NAME_DISPLAY = "Cosmos Worker name";
-
     static final String COSMOS_MESSAGE_KEY_ENABLED_CONF = "connect.cosmosdb.messagekey.enabled";
     private static final String COSMOS_MESSAGE_KEY_ENABLED_DEFAULT = "true";
     private static final String COSMOS_MESSAGE_KEY_ENABLED_DOC = "Whether to set the Kafka message key.";
@@ -75,16 +60,24 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         + "  was monitored by a source task.";
     private static final String COSMOS_USE_LATEST_OFFSET_DISPLAY = "Use latest offset";
 
+
+    static final String COSMOS_ASSIGNED_CONTAINER_CONF = "connect.cosmosdb.assigned.container";
+
+    static final String COSMOS_WORKER_NAME_CONF = "connect.cosmosdb.worker.name";
+    static final String COSMOS_WORKER_NAME_DEFAULT = "worker";
+
+    // Variables defined as Connect configs
     private Long timeout;
     private Long bufferSize;
     private Long batchSize;
     private Long pollInterval;
-    private String containersList;
-    private String assignedContainer;
-    private String workerName;
     private Boolean messageKeyEnabled;
     private String messageKeyField;
     private Boolean useLatestOffset;
+
+    // Variables not defined as Connect configs, should not be exposed when creating connector
+    private String workerName;
+    private String assignedContainer;
 
     public CosmosDBSourceConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -97,12 +90,13 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         bufferSize = this.getLong(COSMOS_SOURCE_TASK_BUFFER_SIZE_CONF);
         batchSize = this.getLong(COSMOS_SOURCE_TASK_BATCH_SIZE_CONF);
         pollInterval = this.getLong(COSMOS_SOURCE_TASK_POLL_INTERVAL_CONF);
-        containersList = this.getString(COSMOS_CONTAINERS_LIST_CONF);
-        assignedContainer = this.getString(COSMOS_ASSIGNED_CONTAINER_CONF);
-        workerName = this.getString(COSMOS_WORKER_NAME_CONF);
         messageKeyEnabled = this.getBoolean(COSMOS_MESSAGE_KEY_ENABLED_CONF);
         messageKeyField = this.getString(COSMOS_MESSAGE_KEY_FIELD_CONF);
         useLatestOffset = this.getBoolean(COSMOS_USE_LATEST_OFFSET_CONF);
+
+        // Since variables are not defined as Connect configs, grab values directly from Map
+        assignedContainer = parsedConfig.get(COSMOS_ASSIGNED_CONTAINER_CONF);
+        workerName = parsedConfig.get(COSMOS_WORKER_NAME_CONF);
     }
 
     public static ConfigDef getConfig() {
@@ -173,17 +167,6 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         
         result
             .define(
-                COSMOS_CONTAINERS_LIST_CONF,
-                Type.STRING,
-                ConfigDef.NO_DEFAULT_VALUE,
-                Importance.HIGH,
-                COSMOS_CONTAINERS_LIST_DOC,
-                databaseGroupName,
-                ++databaseGroupOrder,
-                Width.MEDIUM,
-                COSMOS_CONTAINERS_LIST_DISPLAY
-            )
-            .define(
                 COSMOS_USE_LATEST_OFFSET_CONF,
                 Type.BOOLEAN,
                 COSMOS_USE_LATEST_OFFSET_DEFAULT,
@@ -193,28 +176,6 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
                 ++databaseGroupOrder,
                 Width.MEDIUM,
                 COSMOS_USE_LATEST_OFFSET_DISPLAY
-            )
-            .define(
-                COSMOS_ASSIGNED_CONTAINER_CONF,
-                Type.STRING,
-                "",
-                Importance.MEDIUM,
-                COSMOS_ASSIGNED_CONTAINER_DOC,
-                databaseGroupName,
-                ++databaseGroupOrder,
-                Width.MEDIUM,
-                COSMOS_ASSIGNED_CONTAINER_DISPLAY
-            )
-            .define(
-                COSMOS_WORKER_NAME_CONF,
-                Type.STRING,
-                COSMOS_WORKER_NAME_DEFAULT,
-                Importance.MEDIUM,
-                COSMOS_WORKER_NAME_DOC,
-                databaseGroupName,
-                ++databaseGroupOrder,
-                Width.MEDIUM,
-                COSMOS_WORKER_NAME_DISPLAY
             );
     }
 
@@ -248,18 +209,6 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
             );
     }
 
-    public String getContainerList() {
-        return this.containersList;
-    }
-
-    public String getAssignedContainer() {
-        return this.assignedContainer;
-    }
-
-    public String getWorkerName() {
-        return this.workerName;
-    }
-
     public Long getTaskTimeout() {
         return this.timeout;
     }
@@ -286,5 +235,21 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
 
     public boolean useLatestOffset() {
         return this.useLatestOffset.booleanValue();
+    }
+
+    // public void setAssignedContainer(String assignedContainer) {
+    //     this.assignedContainer = assignedContainer;
+    // }
+
+    public String getAssignedContainer() {
+        return this.assignedContainer;
+    }
+
+    // public void setWorkerName(String workerName) {
+    //     this.workerName = workerName;
+    // }
+
+    public String getWorkerName() {
+        return this.workerName;
     }
 }

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
@@ -237,17 +237,9 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         return this.useLatestOffset.booleanValue();
     }
 
-    // public void setAssignedContainer(String assignedContainer) {
-    //     this.assignedContainer = assignedContainer;
-    // }
-
     public String getAssignedContainer() {
         return this.assignedContainer;
     }
-
-    // public void setWorkerName(String workerName) {
-    //     this.workerName = workerName;
-    // }
 
     public String getWorkerName() {
         return this.workerName;

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnector.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnector.java
@@ -1,5 +1,6 @@
 package com.azure.cosmos.kafka.connect.source;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -52,7 +53,9 @@ public class CosmosDBSourceConnector extends SourceConnector {
             taskProps.put(CosmosDBSourceConfig.COSMOS_ASSIGNED_CONTAINER_CONF,
                           containerList.get(i % containerList.size()));
             taskProps.put(CosmosDBSourceConfig.COSMOS_WORKER_NAME_CONF, 
-                          CosmosDBSourceConfig.COSMOS_WORKER_NAME_DEFAULT + i);
+                          String.format("%s-%d-%d", 
+                                CosmosDBSourceConfig.COSMOS_WORKER_NAME_DEFAULT,
+                                RandomUtils.nextLong(1L, 9999999L), i));
             taskConfigs.add(taskProps);
         }
 

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnector.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnector.java
@@ -38,10 +38,10 @@ public class CosmosDBSourceConnector extends SourceConnector {
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
         logger.info("Creating the task Configs");
-        String[] containerList = StringUtils.split(config.getContainerList(), ",");
+        List<String> containerList = config.getTopicContainerMap().getContainerList();
         List<Map<String, String>> taskConfigs = new ArrayList<>(maxTasks);
 
-        if (containerList.length == 0) {
+        if (containerList.size() == 0) {
             logger.debug("Container list is not specified");
             return taskConfigs;
         }
@@ -50,8 +50,9 @@ public class CosmosDBSourceConnector extends SourceConnector {
             // Equally distribute workers by assigning workers to containers in round robin fashion.
             Map<String, String> taskProps = config.originalsStrings();
             taskProps.put(CosmosDBSourceConfig.COSMOS_ASSIGNED_CONTAINER_CONF,
-                          containerList[i % containerList.length]);
-            taskProps.put(CosmosDBSourceConfig.COSMOS_WORKER_NAME_CONF, config.getWorkerName() + i);
+                          containerList.get(i % containerList.size()));
+            taskProps.put(CosmosDBSourceConfig.COSMOS_WORKER_NAME_CONF, 
+                          CosmosDBSourceConfig.COSMOS_WORKER_NAME_DEFAULT + i);
             taskConfigs.add(taskProps);
         }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfigTest.java
@@ -16,7 +16,6 @@ public class CosmosDBSourceConfigTest {
         configs.put(CosmosDBSourceConfig.COSMOS_CONN_KEY_CONF, "mykey");
         configs.put(CosmosDBSourceConfig.COSMOS_DATABASE_NAME_CONF, "mydb");
         configs.put(CosmosDBSourceConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "mytopic5#mycontainer6");
-        configs.put(CosmosDBSourceConfig.COSMOS_CONTAINERS_LIST_CONF, "mycontainer6");
         return configs;
     }
 
@@ -29,7 +28,6 @@ public class CosmosDBSourceConfigTest {
         assertEquals("mykey", config.getConnKey());
         assertEquals("mydb", config.getDatabaseName());
         assertEquals("mycontainer6", config.getTopicContainerMap().getContainerForTopic("mytopic5").get());
-        assertEquals("mycontainer6", config.getContainerList());
     }
 
     @Test
@@ -40,8 +38,6 @@ public class CosmosDBSourceConfigTest {
         assertEquals(10000L, config.getTaskBufferSize().longValue());
         assertEquals(100L, config.getTaskBatchSize().longValue());
         assertEquals(1000L, config.getTaskPollInterval().longValue());
-        assertEquals("", config.getAssignedContainer());
-        assertEquals("worker", config.getWorkerName());
         assertFalse(config.useLatestOffset());
     }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnectorTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.*;
 public class CosmosDBSourceConnectorTest {
 
     private static final String ASSIGNED_CONTAINER = CosmosDBSourceConfig.COSMOS_ASSIGNED_CONTAINER_CONF;
+    private static final String WORKER_NAME = CosmosDBSourceConfig.COSMOS_WORKER_NAME_CONF;
     private static final String BATCH_SETTING_NAME = CosmosDBSourceConfig.COSMOS_SOURCE_TASK_BATCH_SIZE_CONF;
     private static final Long BATCH_SETTING = new CosmosDBSourceConfig(CosmosDBSourceConfigTest.setupConfigs()).getTaskBatchSize();
 
@@ -35,7 +36,7 @@ public class CosmosDBSourceConnectorTest {
     public void testAbsentDefaults(){
         //Containers list is set in connector and does not have a default setting. Let's see if the configdef does
         assertNull(new CosmosDBSourceConnector().config().defaultValues()
-            .get(CosmosDBSourceConfig.COSMOS_CONTAINERS_LIST_CONF));
+            .get(ASSIGNED_CONTAINER));
     }
 
     @Test
@@ -69,17 +70,34 @@ public class CosmosDBSourceConnectorTest {
     @Test
     public void testValidTaskConfigContainerAssignment(){
         Map<String, String> settingAssignment = CosmosDBSourceConfigTest.setupConfigs();
-        settingAssignment.put(CosmosDBSourceConfig.COSMOS_CONTAINERS_LIST_CONF, "C1,C2,C3,C4");
+        settingAssignment.put(CosmosDBSourceConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "T1#C1,T2#C2,T3#C3,T4#C4");
         CosmosDBSourceConnector sourceConnector = new CosmosDBSourceConnector();
         sourceConnector.start(settingAssignment);
         List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(6);
 
         assertEquals(6, taskConfigs.size());
-        assertEquals("C1", taskConfigs.get(0).get(ASSIGNED_CONTAINER));
-        assertEquals("C2", taskConfigs.get(1).get(ASSIGNED_CONTAINER));
-        assertEquals("C3", taskConfigs.get(2).get(ASSIGNED_CONTAINER));
-        assertEquals("C4", taskConfigs.get(3).get(ASSIGNED_CONTAINER));
-        assertEquals("C1", taskConfigs.get(4).get(ASSIGNED_CONTAINER));
-        assertEquals("C2", taskConfigs.get(5).get(ASSIGNED_CONTAINER));
+        assertEquals("C4", taskConfigs.get(0).get(ASSIGNED_CONTAINER));
+        assertEquals("C1", taskConfigs.get(1).get(ASSIGNED_CONTAINER));
+        assertEquals("C2", taskConfigs.get(2).get(ASSIGNED_CONTAINER));
+        assertEquals("C3", taskConfigs.get(3).get(ASSIGNED_CONTAINER));
+        assertEquals("C4", taskConfigs.get(4).get(ASSIGNED_CONTAINER));
+        assertEquals("C1", taskConfigs.get(5).get(ASSIGNED_CONTAINER));
+    }
+
+    @Test
+    public void testValidTaskConfigWorkerNameAssignment(){
+        Map<String, String> settingAssignment = CosmosDBSourceConfigTest.setupConfigs();
+        settingAssignment.put(CosmosDBSourceConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "T1#C1");
+        CosmosDBSourceConnector sourceConnector = new CosmosDBSourceConnector();
+        sourceConnector.start(settingAssignment);
+        List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(6);
+
+        assertEquals(6, taskConfigs.size());
+        assertEquals("worker0", taskConfigs.get(0).get(WORKER_NAME));
+        assertEquals("worker1", taskConfigs.get(1).get(WORKER_NAME));
+        assertEquals("worker2", taskConfigs.get(2).get(WORKER_NAME));
+        assertEquals("worker3", taskConfigs.get(3).get(WORKER_NAME));
+        assertEquals("worker4", taskConfigs.get(4).get(WORKER_NAME));
+        assertEquals("worker5", taskConfigs.get(5).get(WORKER_NAME));
     }
 }

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConnectorTest.java
@@ -83,21 +83,4 @@ public class CosmosDBSourceConnectorTest {
         assertEquals("C4", taskConfigs.get(4).get(ASSIGNED_CONTAINER));
         assertEquals("C1", taskConfigs.get(5).get(ASSIGNED_CONTAINER));
     }
-
-    @Test
-    public void testValidTaskConfigWorkerNameAssignment(){
-        Map<String, String> settingAssignment = CosmosDBSourceConfigTest.setupConfigs();
-        settingAssignment.put(CosmosDBSourceConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "T1#C1");
-        CosmosDBSourceConnector sourceConnector = new CosmosDBSourceConnector();
-        sourceConnector.start(settingAssignment);
-        List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(6);
-
-        assertEquals(6, taskConfigs.size());
-        assertEquals("worker0", taskConfigs.get(0).get(WORKER_NAME));
-        assertEquals("worker1", taskConfigs.get(1).get(WORKER_NAME));
-        assertEquals("worker2", taskConfigs.get(2).get(WORKER_NAME));
-        assertEquals("worker3", taskConfigs.get(3).get(WORKER_NAME));
-        assertEquals("worker4", taskConfigs.get(4).get(WORKER_NAME));
-        assertEquals("worker5", taskConfigs.get(5).get(WORKER_NAME));
-    }
 }

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/integration/SourceConnectorIT.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/integration/SourceConnectorIT.java
@@ -183,7 +183,6 @@ public class SourceConnectorIT {
             .withConfig("key.converter.schemas.enable", config.get("key.converter.schemas.enable").textValue())
             .withConfig("connect.cosmosdb.task.poll.interval", config.get("connect.cosmosdb.task.poll.interval").textValue())
             .withConfig("connect.cosmosdb.offset.useLatest", config.get("connect.cosmosdb.offset.useLatest").booleanValue())
-            .withConfig("connect.cosmosdb.containers", config.get("connect.cosmosdb.containers").textValue())
             .withConfig("connect.cosmosdb.connection.endpoint", config.get("connect.cosmosdb.connection.endpoint").textValue())
             .withConfig("connect.cosmosdb.master.key", config.get("connect.cosmosdb.master.key").textValue())
             .withConfig("connect.cosmosdb.databasename", config.get("connect.cosmosdb.databasename").textValue())
@@ -443,9 +442,6 @@ public class SourceConnectorIT {
         Map<String, String> currentParams = connectConfig.build().getConfig();
         Builder multiWorkerConfigBuilder = connectConfig
             .withConfig("tasks.max", 2)
-            .withConfig("connect.cosmosdb.containers", 
-                currentParams.get("connect.cosmosdb.containers") 
-                + String.format(",%s", SECOND_COSMOS_CONTAINER))
             .withConfig("connect.cosmosdb.containers.topicmap", 
                 currentParams.get("connect.cosmosdb.containers.topicmap") 
                 + String.format(",%s#%s", SECOND_KAFKA_TOPIC, SECOND_COSMOS_CONTAINER));


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Removing config container list from source connector since this info can be obtained from topic-container map
Also removed worker name and assigned container since these shouldn't matter to the end user

## Issues Closed or Referenced

- Closes #277