### PR TITLE
Adds validations for CosmosDBSink connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
@@ -3,8 +3,17 @@ package com.azure.cosmos.kafka.connect.sink;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.kafka.connect.CosmosDBConfig;
+import com.azure.cosmos.kafka.connect.TopicContainerMap;
+import com.azure.cosmos.models.CosmosDatabaseProperties;
+import com.azure.cosmos.util.CosmosPagedIterable;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
@@ -14,6 +23,11 @@ import org.slf4j.LoggerFactory;
  * A Sink connector that publishes topic messages to CosmosDB.
  */
 public class CosmosDBSinkConnector extends SinkConnector {
+
+    private static final String INVALID_TOPIC_MAP_FORMAT =
+        "Invalid entry for topic-container map. The topic-container map should be a comma-delimited "
+            + "list of Kafka topic to Cosmos containers. Each mapping should be a pair of Kafka "
+            + "topic and Cosmos container separated by '#'. For example: topic1#con1,topic2#con2.";
 
     private static final Logger logger = LoggerFactory.getLogger(CosmosDBSinkConnector.class);
     private Map<String, String> configProps;
@@ -48,9 +62,61 @@ public class CosmosDBSinkConnector extends SinkConnector {
     public ConfigDef config() {
         return CosmosDBSinkConfig.getConfig();
     }
-    
+
     @Override
     public String version() {
         return this.getClass().getPackage().getImplementationVersion();
     }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        Config config = super.validate(connectorConfigs);
+        if (config.configValues().stream().anyMatch(cv -> !cv.errorMessages().isEmpty())) {
+            return config;
+        }
+
+        Map<String, ConfigValue> configValues = config.configValues().stream().collect(
+            Collectors.toMap(ConfigValue::name, Function.identity()));
+
+        validateConnection(connectorConfigs, configValues);
+        validateTopicMap(connectorConfigs, configValues);
+
+        return config;
+    }
+
+    private void validateConnection(Map<String, String> connectorConfigs, Map<String, ConfigValue> configValues) {
+        String endpoint = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF);
+        String key = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF);
+        try {
+            readAllDatabases(endpoint, key);
+        } catch (Exception e) {
+            configValues.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF)
+                .addErrorMessage("Could not connect to endpoint with error: " + e.getMessage());
+            configValues.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF)
+                .addErrorMessage("Could not connect to endpoint with error: " + e.getMessage());
+        }
+    }
+
+    private void validateTopicMap(Map<String, String> connectorConfigs,
+        Map<String, ConfigValue> configValues) {
+
+        String topicMap = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF);
+        try {
+            TopicContainerMap.deserialize(topicMap);
+        } catch (Exception e) {
+            configValues.get(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF)
+                .addErrorMessage(INVALID_TOPIC_MAP_FORMAT);
+        }
+    }
+
+    // visible for testing
+    CosmosPagedIterable<CosmosDatabaseProperties> readAllDatabases(String endpoint, String key) {
+        return new CosmosClientBuilder()
+            .endpoint(endpoint)
+            .key(key)
+            .userAgentSuffix(CosmosDBConfig.COSMOS_CLIENT_USER_AGENT_SUFFIX + version())
+            .buildClient()
+            .readAllDatabases();
+    }
 }
+

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
@@ -6,11 +6,10 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.kafka.connect.CosmosDBConfig;
 import com.azure.cosmos.kafka.connect.TopicContainerMap;
-import com.azure.cosmos.models.CosmosDatabaseProperties;
-import com.azure.cosmos.util.CosmosPagedIterable;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
@@ -88,7 +87,7 @@ public class CosmosDBSinkConnector extends SinkConnector {
         String endpoint = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF);
         String key = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF);
         try {
-            readAllDatabases(endpoint, key);
+            createClient(endpoint, key);
         } catch (Exception e) {
             configValues.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF)
                 .addErrorMessage("Could not connect to endpoint with error: " + e.getMessage());
@@ -110,13 +109,14 @@ public class CosmosDBSinkConnector extends SinkConnector {
     }
 
     // visible for testing
-    CosmosPagedIterable<CosmosDatabaseProperties> readAllDatabases(String endpoint, String key) {
-        return new CosmosClientBuilder()
+    void createClient(String endpoint, String key) {
+        try (CosmosClient unused = new CosmosClientBuilder()
             .endpoint(endpoint)
             .key(key)
             .userAgentSuffix(CosmosDBConfig.COSMOS_CLIENT_USER_AGENT_SUFFIX + version())
-            .buildClient()
-            .readAllDatabases();
+            .buildClient()) {
+            // Just try to create the client to validate connectivity to the endpoint with key.
+        }
     }
 }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -36,7 +37,7 @@ public class CosmosDBSinkConnectorTest {
     CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
     doThrow(new IllegalArgumentException())
         .when(connector)
-        .readAllDatabases(anyString(), anyString());
+        .createClient(anyString(), anyString());
 
     Config config = connector.validate(ImmutableMap.of(
         CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
@@ -53,9 +54,9 @@ public class CosmosDBSinkConnectorTest {
   @Test
   public void testValidateHappyPath() {
     CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
-    doReturn(null)
+    doNothing()
         .when(connector)
-        .readAllDatabases(anyString(), anyString());
+        .createClient(anyString(), anyString());
 
     Config config = connector.validate(ImmutableMap.of(
         CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
@@ -72,9 +73,9 @@ public class CosmosDBSinkConnectorTest {
   @Test
   public void testValidateTopicMapValidFormat() {
     CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
-    doReturn(null)
+    doNothing()
         .when(connector)
-        .readAllDatabases(anyString(), anyString());
+        .createClient(anyString(), anyString());
 
     invalidTopicMapString(connector, "topicOnly");
     invalidTopicMapString(connector, "#containerOnly");

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
@@ -1,0 +1,97 @@
+package com.azure.cosmos.kafka.connect.sink;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class CosmosDBSinkConnectorTest {
+
+  @Test
+  public void testValidateEmptyConfigFailsRequiredFields() {
+    Config config = new CosmosDBSinkConnector().validate(ImmutableMap.of());
+
+    Map<String, List<String>> errorMessages = config.configValues().stream()
+        .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF), not(empty()));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF), not(empty()));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF), not(empty()));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF), not(empty()));
+  }
+
+  @Test
+  public void testValidateCannotConnectToCosmos() {
+    CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
+    doThrow(new IllegalArgumentException())
+        .when(connector)
+        .readAllDatabases(anyString(), anyString());
+
+    Config config = connector.validate(ImmutableMap.of(
+        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
+        CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
+        CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
+        CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "topic#container"
+    ));
+    Map<String, List<String>> errorMessages = config.configValues().stream()
+        .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF), not(empty()));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF), not(empty()));
+  }
+
+  @Test
+  public void testValidateHappyPath() {
+    CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
+    doReturn(null)
+        .when(connector)
+        .readAllDatabases(anyString(), anyString());
+
+    Config config = connector.validate(ImmutableMap.of(
+        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
+        CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
+        CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
+        CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "topic#container"
+    ));
+    for (ConfigValue value : config.configValues()) {
+      assertThat("Expecting empty error message for config " + value.name(),
+          value.errorMessages(), empty());
+    }
+  }
+
+  @Test
+  public void testValidateTopicMapValidFormat() {
+    CosmosDBSinkConnector connector = spy(CosmosDBSinkConnector.class);
+    doReturn(null)
+        .when(connector)
+        .readAllDatabases(anyString(), anyString());
+
+    invalidTopicMapString(connector, "topicOnly");
+    invalidTopicMapString(connector, "#containerOnly");
+    invalidTopicMapString(connector, ",,,,,");
+    invalidTopicMapString(connector, "###");
+    invalidTopicMapString(connector, "partially#correct,but,not#entirely");
+  }
+
+  private void invalidTopicMapString(CosmosDBSinkConnector connector, String topicMapConfig) {
+    Config config = connector.validate(ImmutableMap.of(
+        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
+        CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
+        CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
+        CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, topicMapConfig
+    ));
+    Map<String, List<String>> errorMessages = config.configValues().stream()
+        .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+    assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF), not(empty()));
+  }
+}


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Implements the `validate` method on CosmosDBSinkConnector

## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
Changes have accompanying unittests.

## Review notes


## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
