### PR TITLE
MINOR: Add non-empty string validation for string configs

### DIFF
--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -92,7 +92,6 @@ public class CosmosDBConfig extends AbstractConfig {
                 COSMOS_CONN_KEY_CONF,
                 Type.PASSWORD,
                 ConfigDef.NO_DEFAULT_VALUE,
-                NON_EMPTY_STRING,
                 Importance.HIGH,
                 COSMOS_CONN_KEY_DOC,
                 connectionGroupName,

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -3,7 +3,9 @@ package com.azure.cosmos.kafka.connect;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.NonEmptyString;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
 import io.confluent.kafka.schemaregistry.utils.EnumRecommender;
@@ -12,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings ({"squid:S1854", "squid:S2160"})  // suppress unneeded int *groupOrder variables, equals method
 public class CosmosDBConfig extends AbstractConfig {
+    private static final Validator NON_EMPTY_STRING = new NonEmptyString();
     
     public static final String COSMOS_CONN_ENDPOINT_CONF = "connect.cosmos.connection.endpoint";
     private static final String COSMOS_CONN_ENDPOINT_DOC = "Cosmos endpoint URL.";
@@ -77,6 +80,7 @@ public class CosmosDBConfig extends AbstractConfig {
                 COSMOS_CONN_ENDPOINT_CONF,
                 Type.STRING,
                 ConfigDef.NO_DEFAULT_VALUE,
+                NON_EMPTY_STRING,
                 Importance.HIGH,
                 COSMOS_CONN_ENDPOINT_DOC,
                 connectionGroupName,
@@ -88,6 +92,7 @@ public class CosmosDBConfig extends AbstractConfig {
                 COSMOS_CONN_KEY_CONF,
                 Type.PASSWORD,
                 ConfigDef.NO_DEFAULT_VALUE,
+                NON_EMPTY_STRING,
                 Importance.HIGH,
                 COSMOS_CONN_KEY_DOC,
                 connectionGroupName,
@@ -109,6 +114,7 @@ public class CosmosDBConfig extends AbstractConfig {
                 COSMOS_DATABASE_NAME_CONF,
                 Type.STRING,
                 ConfigDef.NO_DEFAULT_VALUE,
+                NON_EMPTY_STRING,
                 Importance.HIGH,
                 COSMOS_DATABASE_NAME_DOC,
                 databaseGroupName,
@@ -120,6 +126,7 @@ public class CosmosDBConfig extends AbstractConfig {
                 COSMOS_CONTAINER_TOPIC_MAP_CONF,
                 Type.STRING,
                 ConfigDef.NO_DEFAULT_VALUE,
+                NON_EMPTY_STRING,
                 Importance.HIGH,
                 COSMOS_CONTAINER_TOPIC_MAP_DOC,
                 databaseGroupName,

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
@@ -52,7 +52,6 @@ public class CosmosDBSinkConfigTest {
     public void shouldThrowExceptionWhenRequiredFieldsEmpty() {
         HashMap<String, String> settings = new HashMap<>();
         settings.put(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "");
-        settings.put(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "");
         settings.put(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "");
         settings.put(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "");
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
@@ -47,4 +47,17 @@ public class CosmosDBSinkConfigTest {
             new CosmosDBSinkConfig(settings);
         });
     }
+
+    @Test
+    public void shouldThrowExceptionWhenRequiredFieldsEmpty() {
+        HashMap<String, String> settings = new HashMap<>();
+        settings.put(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "");
+        settings.put(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "");
+        settings.put(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "");
+        settings.put(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, "");
+
+        assertThrows(ConfigException.class, () -> {
+            new CosmosDBSinkConfig(settings);
+        });
+    }
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Adds some minor validation on string config properties that should be non empty

## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
Yes. A unittest was added to verify behavior when empty string is specified.

## Review notes

## Issues Closed or Referenced
References #372 
