### PR TITLE
Remove support for sink connector insert mode

### DIFF
--- a/doc/README_Sink.md
+++ b/doc/README_Sink.md
@@ -176,7 +176,6 @@ The following settings are used to configure the Cosmos DB Kafka Sink Connector.
 | connect.cosmos.master.key | string | The Cosmos primary key that the sink connects with | Required |
 | connect.cosmos.databasename | string | The name of the Cosmos database the sink writes to | Required |
 | connect.cosmos.containers.topicmap | string | Mapping between Kafka Topics and Cosmos Containers, formatted using CSV as shown: `topic#container,topic2#container2` | Required |
-| connect.cosmos.sink.useUpsert | boolean | Whether to upsert items into Cosmos DB. Default is `false`. | Optional |
 | key.converter | string | Serialization format for the key data written into Kafka topic | Required |
 | value.converter | string | Serialization format for the value data written into the Kafka topic | Required |
 | key.converter.schemas.enable | string | Set to `"true"` if the key data has embedded schema | Optional |

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
          

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -52,11 +53,6 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
             <version>4.11.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry-maven-plugin</artifactId>
-            <version>6.0.1</version>
         </dependency>
 
         <!-- Apache commons -->

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -8,8 +8,6 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
-import io.confluent.kafka.schemaregistry.utils.EnumRecommender;
-
 import java.util.Map;
 
 @SuppressWarnings ({"squid:S1854", "squid:S2160"})  // suppress unneeded int *groupOrder variables, equals method
@@ -36,13 +34,6 @@ public class CosmosDBConfig extends AbstractConfig {
 
     public static final int COSMOS_DATABASE_GROUP_ORDER = 2;
     public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
-
-    public static final EnumRecommender BOOLEAN_RECOMMENDER = EnumRecommender.in(BooleanValues.values());
-
-    public enum BooleanValues {
-        TRUE,
-        FALSE
-    }
 
     private String connEndpoint;
     private String connKey;

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfig.java
@@ -15,54 +15,11 @@ import com.azure.cosmos.kafka.connect.CosmosDBConfig;
 
 @SuppressWarnings ({"squid:S1854", "squid:S2160"})  // suppress unneeded int *groupOrder variables, equals method
 public class CosmosDBSinkConfig extends CosmosDBConfig {
-
-    static final String COSMOS_USE_UPSERT_CONF = "connect.cosmos.sink.useUpsert";
-    private static final String COSMOS_USE_UPSERT_DEFAULT = "false";
-    private static final String COSMOS_USE_UPSERT_DOC = "Behaviour of operation to Cosmos."
-        + " 'false' is the default value and signals that all operations to Cosmos are Insert;"
-        + " 'true' changes the behaviour to use Upsert operation.";
-    private static final String COSMOS_USE_UPSERT_DISPLAY = "Use Cosmos Upsert";
-
-    private String useUpsert;
-
     public CosmosDBSinkConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
     }
 
     public CosmosDBSinkConfig(Map<String, String> parsedConfig) {
         super(getConfig(), parsedConfig);
-
-        useUpsert = this.getString(COSMOS_USE_UPSERT_CONF);
-    }
-
-    public static ConfigDef getConfig() {
-        ConfigDef result = CosmosDBConfig.getConfig();
-        
-        defineDatabaseConfigs(result);
-
-        return result;
-    }
-
-    private static void defineDatabaseConfigs(ConfigDef result) {
-        final String databaseGroupName = "Database";
-        int databaseGroupOrder = CosmosDBConfig.COSMOS_DATABASE_GROUP_ORDER;
-        
-        result.define(
-            COSMOS_USE_UPSERT_CONF,
-            Type.STRING,
-            COSMOS_USE_UPSERT_DEFAULT,
-            BOOLEAN_RECOMMENDER,
-            Importance.MEDIUM,
-            COSMOS_USE_UPSERT_DOC,
-            databaseGroupName,
-            ++databaseGroupOrder,
-            Width.MEDIUM,
-            COSMOS_USE_UPSERT_DISPLAY,
-            BOOLEAN_RECOMMENDER
-        );
-    }
-  
-    public String getUseUpsert() {
-        return this.useUpsert;
     }
 }

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -90,11 +90,7 @@ public class CosmosDBSinkTask extends SinkTask {
     }
 
     private void addItemToContainer(CosmosContainer container, Object recordValue) {
-        if (config.getUseUpsert().equalsIgnoreCase(CosmosDBConfig.BooleanValues.TRUE.toString())) {
-            container.upsertItem(recordValue);
-        } else {
-            container.createItem(recordValue);
-        }
+        container.upsertItem(recordValue);
     }
 
     @Override

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfig.java
@@ -70,9 +70,9 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
     private Long bufferSize;
     private Long batchSize;
     private Long pollInterval;
-    private String messageKeyEnabled;
+    private boolean messageKeyEnabled;
     private String messageKeyField;
-    private String useLatestOffset;
+    private boolean useLatestOffset;
 
     // Variables not defined as Connect configs, should not be exposed when creating connector
     private String workerName;
@@ -89,9 +89,9 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         bufferSize = this.getLong(COSMOS_SOURCE_TASK_BUFFER_SIZE_CONF);
         batchSize = this.getLong(COSMOS_SOURCE_TASK_BATCH_SIZE_CONF);
         pollInterval = this.getLong(COSMOS_SOURCE_TASK_POLL_INTERVAL_CONF);
-        messageKeyEnabled = this.getString(COSMOS_MESSAGE_KEY_ENABLED_CONF);
+        messageKeyEnabled = this.getBoolean(COSMOS_MESSAGE_KEY_ENABLED_CONF);
         messageKeyField = this.getString(COSMOS_MESSAGE_KEY_FIELD_CONF);
-        useLatestOffset = this.getString(COSMOS_USE_LATEST_OFFSET_CONF);
+        useLatestOffset = this.getBoolean(COSMOS_USE_LATEST_OFFSET_CONF);
 
         // Since variables are not defined as Connect configs, grab values directly from Map
         assignedContainer = parsedConfig.get(COSMOS_ASSIGNED_CONTAINER_CONF);
@@ -166,16 +166,14 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         result
             .define(
                 COSMOS_USE_LATEST_OFFSET_CONF,
-                Type.STRING,
+                Type.BOOLEAN,
                 COSMOS_USE_LATEST_OFFSET_DEFAULT,
-                BOOLEAN_RECOMMENDER,
                 Importance.HIGH,
                 COSMOS_USE_LATEST_OFFSET_DOC,
                 databaseGroupName,
                 ++databaseGroupOrder,
                 Width.MEDIUM,
-                COSMOS_USE_LATEST_OFFSET_DISPLAY,
-                BOOLEAN_RECOMMENDER
+                COSMOS_USE_LATEST_OFFSET_DISPLAY
             );
     }
 
@@ -186,16 +184,14 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         result
             .define(
                 COSMOS_MESSAGE_KEY_ENABLED_CONF,
-                Type.STRING,
+                Type.BOOLEAN,
                 COSMOS_MESSAGE_KEY_ENABLED_DEFAULT,
-                BOOLEAN_RECOMMENDER,
                 Importance.MEDIUM,
                 COSMOS_MESSAGE_KEY_ENABLED_DOC,
                 messageGroupName,
                 messageGroupOrder++,
                 Width.SHORT,
-                COSMOS_MESSAGE_KEY_ENABLED_DISPLAY,
-                BOOLEAN_RECOMMENDER
+                COSMOS_MESSAGE_KEY_ENABLED_DISPLAY
             )
             .define(
                 COSMOS_MESSAGE_KEY_FIELD_CONF,
@@ -227,7 +223,7 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         return this.pollInterval;
     }
 
-    public String isMessageKeyEnabled() {
+    public boolean isMessageKeyEnabled() {
         return this.messageKeyEnabled;
     }
 
@@ -235,7 +231,7 @@ public class CosmosDBSourceConfig extends CosmosDBConfig {
         return this.messageKeyField;
     }
 
-    public String useLatestOffset() {
+    public boolean useLatestOffset() {
         return this.useLatestOffset;
     }
 

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTask.java
@@ -70,7 +70,7 @@ public class CosmosDBSourceTask extends SourceTask {
         
         Map<String, Object> offset = context.offsetStorageReader().offset(partitionMap);
         // If NOT using the latest offset, reset lease container token to earliest possible value
-        if (config.useLatestOffset().equalsIgnoreCase(CosmosDBConfig.BooleanValues.FALSE.toString())) {
+        if (!config.useLatestOffset()) {
             updateContinuationToken(ZERO_CONTINUATION_TOKEN);
         } else if (offset != null) {
             // Check for previous offset and compare with lease container token
@@ -173,7 +173,7 @@ public class CosmosDBSourceTask extends SourceTask {
             try {                
                 // Set the Kafka message key if option is enabled and field is configured in document
                 String messageKey = "";
-                if (config.isMessageKeyEnabled().equalsIgnoreCase(CosmosDBConfig.BooleanValues.TRUE.toString())) {
+                if (config.isMessageKeyEnabled()) {
                     JsonNode messageKeyFieldNode = node.get(config.getMessageKeyField());
                     messageKey = (messageKeyFieldNode != null) ? messageKeyFieldNode.toString() : "";
                 }

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConfigTest.java
@@ -32,13 +32,6 @@ public class CosmosDBSinkConfigTest {
     }
 
     @Test
-    public void shouldHaveDefaultValues() {
-        // Adding required Configuration with no default value.
-        CosmosDBSinkConfig config = new CosmosDBSinkConfig(setupConfigs());
-        assertTrue(config.getUseUpsert().equalsIgnoreCase("false"));
-    }
-
-    @Test
     public void shouldThrowExceptionWhenCosmosEndpointNotGiven() {
         // Adding required Configuration with no default value.
         HashMap<String, String> settings = setupConfigs();

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorConfigTest.java
@@ -33,15 +33,6 @@ public class CosmosDBSinkConnectorConfigTest {
     }
 
     @Test
-    public void testPresentDefaults(){
-        //The task useUpsert has a default setting. Let's see if the configdef does
-        String useUpsert = new CosmosDBSinkConfig(CosmosDBSinkConfigTest.setupConfigs()).getUseUpsert();
-        assertNotNull(useUpsert);
-        assertEquals(useUpsert, new CosmosDBSinkConnector().config().defaultValues()
-            .get(CosmosDBSinkConfig.COSMOS_USE_UPSERT_CONF));
-    }
-
-    @Test
     public void testTaskConfigs(){
         Map<String, String> settingAssignment = CosmosDBSinkConfigTest.setupConfigs();
         CosmosDBSinkConnector sinkConnector = new CosmosDBSinkConnector();

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTest.java
@@ -42,7 +42,6 @@ public class CosmosDBSinkTaskTest {
         Map<String, String> settingAssignment = CosmosDBSinkConfigTest.setupConfigs();
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, topicName + "#" + containerName);
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, databaseName);
-        settingAssignment.put(CosmosDBSinkConfig.COSMOS_USE_UPSERT_CONF, upsertFalse);
         CosmosDBSinkConfig config = new CosmosDBSinkConfig(settingAssignment);
         FieldUtils.writeField(testTask, "config", config, true);
 
@@ -64,7 +63,7 @@ public class CosmosDBSinkTaskTest {
         assertNotNull(record.value());
 
         //Make mock connector to serialize a non-JSON payload
-        when(mockContainer.createItem(any())).then((invocation) -> {
+        when(mockContainer.upsertItem(any())).then((invocation) -> {
             Object item = invocation.getArgument(0);
             //Will throw exception:
             try {
@@ -85,7 +84,7 @@ public class CosmosDBSinkTaskTest {
             fail("Expected ConnectException, but got: " + t.getClass().getName());
         }
 
-        verify(mockContainer, times(1)).createItem("foo");
+        verify(mockContainer, times(1)).upsertItem("foo");
     }
 
     @Test
@@ -98,7 +97,7 @@ public class CosmosDBSinkTaskTest {
         SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", mapSchema, map, 0L);
         assertNotNull(record.value());
         testTask.put(Arrays.asList(record));
-        verify(mockContainer, times(1)).createItem(map);
+        verify(mockContainer, times(1)).upsertItem(map);
     }
 }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfigTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceConfigTest.java
@@ -38,7 +38,7 @@ public class CosmosDBSourceConfigTest {
         assertEquals(10000L, config.getTaskBufferSize().longValue());
         assertEquals(100L, config.getTaskBatchSize().longValue());
         assertEquals(1000L, config.getTaskPollInterval().longValue());
-        assertTrue(config.useLatestOffset().equalsIgnoreCase("false"));
+        assertFalse(config.useLatestOffset());
     }
 
     @Test


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
As described in #381 , running the connector in INSERT mode can be problematic when the entire batch is retried for a single failed message in batch. The successfully INSERTed messages within the batch are retried and will fail due to duplicate key. This commit thus removes support for INSERT mode and only allows for records to be written with `upsertItem` .

## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
N/A

## Review notes
After removal of `connect.cosmos.sink.useUpsert` config, `CosmosDBSinkConfig` is essentially empty. I kept it around in case there is the need for separate sink-only configs in the future. But, it could be removed and the sink connector could use the base `CosmosDBConfig` directly.

## Issues Closed or Referenced
Closes #381 

