### PR TITLE
CCDB-3949: remove problematic dependencies that have CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <kafka.version>2.7.0</kafka.version>
         <log4j.version>2.14.0</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
     </properties>
 
     <repositories>
@@ -45,14 +46,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-cosmos</artifactId>
+            <version>4.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
-            <artifactId>azure-cosmos</artifactId>
-            <version>4.11.0</version>
+            <artifactId>azure-core-http-netty</artifactId>
+            <version>1.9.2</version>
         </dependency>
 
         <!-- Apache commons -->
@@ -83,6 +84,17 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <version>${confluent-log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
-            <version>4.14.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-core-http-netty</artifactId>
-            <version>1.9.2</version>
+            <version>4.15.0</version>
         </dependency>
 
         <!-- Apache commons -->


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
As described in #380 , there are a number of dependencies pulled in transitively that have CVE issues discovered in Twistlock. This PR aims to remove these dependencies by:
- Bumping `azure-cosmos` version to latest version
- Bumping `azure-core-http-netty` version to latest version
- Explicitly replacing `log4j:log4j:1.2.17` with `io.confluent:confluent-log4j:1.2.17-cp2`

The twistlock scan after applying this PR contains no critical or high severity CVEs
![Screen Shot 2021-05-13 at 1 02 38 PM](https://user-images.githubusercontent.com/816633/118181290-6e5a5680-b3ec-11eb-84ee-cd1562733b90.png)


## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
Verified CVE fixes in Twistlock. Sanity check the connector after applying this PR with scripts in https://github.com/vdesabou/kafka-docker-playground/tree/master/connect/connect-azure-cosmosdb-sink

## Review notes
The change includes changes from #382 . Please focus this review on changes in `pom.xml` only. I will refresh this PR once #382 has been merged.

## Issues Closed or Referenced
Closes #380 

