### PR TITLE
MINOR: bump json-path to version 2.6.0 to pick up fix for CVE-2021-27568

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0</version>
         </dependency>
 
         <!-- Apache commons -->

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -69,7 +69,7 @@ public class CosmosDBSinkTask extends SinkTask {
                 logger.debug("Writing record, value type: {}", record.value().getClass().getName());
                 logger.debug("Key Schema: {}", record.keySchema());
                 logger.debug("Value schema: {}", record.valueSchema());
-                logger.debug("Value.toString(): {}", record.value() != null ? record.value().toString() : "<null>");
+                logger.trace("Value.toString(): {}", record.value() != null ? record.value().toString() : "<null>");
 
                 Object recordValue;
                 if (record.value() instanceof Struct) {
@@ -79,7 +79,7 @@ public class CosmosDBSinkTask extends SinkTask {
                 }
 
                 maybeInsertId(recordValue, record);
-                logger.debug("Value after inserting ID: {}", recordValue);
+                logger.trace("Value after inserting ID: {}", recordValue);
 
                 try {
                     addItemToContainer(container, recordValue);


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Bump json-path version to 2.6.0 to pick up fix for CVE-2021-27568. Also, minor tweak to log user data at lower log level.

## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
no

## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
