### PR TITLE
CCDB-4120: Adds explicit validation on endpoint URI

### DIFF
--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnector.java
@@ -1,9 +1,14 @@
 package com.azure.cosmos.kafka.connect.sink;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.azure.cosmos.CosmosClient;
@@ -12,6 +17,7 @@ import com.azure.cosmos.kafka.connect.CosmosDBConfig;
 import com.azure.cosmos.kafka.connect.TopicContainerMap;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
@@ -22,6 +28,9 @@ import org.slf4j.LoggerFactory;
  * A Sink connector that publishes topic messages to CosmosDB.
  */
 public class CosmosDBSinkConnector extends SinkConnector {
+    private static final String VALID_ENDPOINT_SCHEMA = "https";
+    private static final int VALID_ENDPOINT_PORT = 443;
+    private static final Pattern VALID_ENDPOINT_COSMOS_INSTANCE_PATTERN = Pattern.compile("[a-z0-9\\-]{3,44}");
 
     private static final String INVALID_TOPIC_MAP_FORMAT =
         "Invalid entry for topic-container map. The topic-container map should be a comma-delimited "
@@ -83,8 +92,44 @@ public class CosmosDBSinkConnector extends SinkConnector {
         return config;
     }
 
+    // VisibleForTesting
+    void validateEndpoint(String endpoint) throws URISyntaxException, UnknownHostException {
+        URI uri = new URI(endpoint);
+        if (!VALID_ENDPOINT_SCHEMA.equalsIgnoreCase(uri.getScheme())) {
+            throw new ConfigException("Endpoint must have schema: " + VALID_ENDPOINT_SCHEMA);
+        }
+        if (VALID_ENDPOINT_PORT != uri.getPort()) {
+            throw new ConfigException("Endpoint must have port: " + VALID_ENDPOINT_PORT);
+        }
+        if (uri.getPath() != null && !uri.getPath().isEmpty() && !uri.getPath().equalsIgnoreCase("/")) {
+            throw new ConfigException("Endpoint must not contain path: " + uri.getPath());
+        }
+        if (uri.getQuery() != null) {
+            throw new ConfigException("Endpoint must not contain query component: " + uri.getQuery());
+        }
+        if (uri.getFragment() != null) {
+            throw new ConfigException("Endpoint must not contain fragment: " + uri.getFragment());
+        }
+        String host = uri.getHost();
+        String cosmosInstance = host.split("\\.")[0];
+        if (!VALID_ENDPOINT_COSMOS_INSTANCE_PATTERN.matcher(cosmosInstance).matches()) {
+            throw new ConfigException("Invalid cosmos instance: " + cosmosInstance);
+        }
+        InetAddress ia = InetAddress.getByName(host);
+        if (ia.isLoopbackAddress() || ia.isLoopbackAddress() || ia.isSiteLocalAddress()) {
+            throw new ConfigException("Invalid host: " + host);
+        }
+    }
+
     private void validateConnection(Map<String, String> connectorConfigs, Map<String, ConfigValue> configValues) {
         String endpoint = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF);
+        try {
+            validateEndpoint(endpoint);
+        } catch (Exception e) {
+            configValues.get(CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF)
+                .addErrorMessage("Invalid endpoint: " + e.getMessage());
+        }
+
         String key = connectorConfigs.get(CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF);
         try {
             createClient(endpoint, key);

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
@@ -2,6 +2,7 @@ package com.azure.cosmos.kafka.connect.sink;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Test;
 
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -59,7 +61,7 @@ public class CosmosDBSinkConnectorTest {
         .createClient(anyString(), anyString());
 
     Config config = connector.validate(ImmutableMap.of(
-        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
+        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://cosmos-instance.documents.azure.com:443/",
         CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
         CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
         CosmosDBSinkConfig.COSMOS_PROVIDER_NAME_CONF, "superAwesomeProvider",
@@ -87,7 +89,7 @@ public class CosmosDBSinkConnectorTest {
 
   private void invalidTopicMapString(CosmosDBSinkConnector connector, String topicMapConfig) {
     Config config = connector.validate(ImmutableMap.of(
-        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
+        CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:443/",
         CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
         CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
         CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, topicMapConfig
@@ -95,5 +97,39 @@ public class CosmosDBSinkConnectorTest {
     Map<String, List<String>> errorMessages = config.configValues().stream()
         .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
     assertThat(errorMessages.get(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF), not(empty()));
+  }
+
+  @Test
+  public void testValidateEndpoint() throws Exception {
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("http://not.valid.schema");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://not.valid.port:1024");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://not.valid.path:443/not/valid/path");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://not.valid.query:443/?query=not-valid");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://INSTANCE.documents.azure.com:443/");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://1.documents.azure.com:443/");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://longlonglonglonglonglonglonglonglonglonglonglonglonglonginstance.documents.azure.com:443/");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://localhost:443/");
+    });
+    assertThrows(ConfigException.class,
+        () -> {new CosmosDBSinkConnector().validateEndpoint("https://[::1]:443/");
+    });
+
+    new CosmosDBSinkConnector().validateEndpoint("https://cosmos-instance.documents.azure.com:443/");
+    new CosmosDBSinkConnector().validateEndpoint("https://cosmos-instance.documents.azure.com:443");
   }
 }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Adds explicit validation on the endpoint URI format before it is used in client creation to validate connectivity.

## Observability + Testing
- What changes or considerations did you make in relation to observability?
N/A

- Did you add testing to account for any new or changed work?
yes

## Review notes
There was concern that a malicious actor may be able to construct a malicious endpoint URI that could be used to execute code remotely. Thus, add more stringent validations on the format that the endpoint URI may have.

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
