### PR TITLE
release 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Release History
 
+### 1.2.2 (2021-12-14)
+#### Key Bug Fixes
+* Upgraded log4j2 to 2.16.0 to address the security vulnerability
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046
+
 ### 1.2.1 (2021-12-10)
-#### New Features
+#### Key Bug Fixes
 * Upgraded log4j2 to 2.15.0 to address the security vulnerability
   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release History
 
+### 1.2.3 (2021-12-20)
+#### Key Bug Fixes
+* Upgraded log4j2 to 2.17.0 to address the security vulnerability
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
+
 ### 1.2.2 (2021-12-14)
 #### Key Bug Fixes
 * Upgraded log4j2 to 2.16.0 to address the security vulnerability

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.azure.cosmos.kafka</groupId>
     <artifactId>kafka-connect-cosmos</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <name> kafka-connect-cosmos</name>
     <url>https://github.com/microsoft/kafka-connect-cosmosdb</url>
@@ -17,7 +17,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <kafka.version>2.7.0</kafka.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.azure.cosmos.kafka</groupId>
     <artifactId>kafka-connect-cosmos</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 
     <name> kafka-connect-cosmos</name>
     <url>https://github.com/microsoft/kafka-connect-cosmosdb</url>
@@ -17,7 +17,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <kafka.version>2.7.0</kafka.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
     </properties>


### PR DESCRIPTION
DoS attack under certain log4j2 <= 2.1.6.0 config.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105

upgrade to log4j2 2.17.0
release 1.2.3