### PR TITLE
1.2.4 upgrade to 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release History
 
+### 1.2.4 (2022-01-05)
+#### Key Bug Fixes
+* Upgraded log4j2 to 2.17.1 to address the security vulnerability
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832
+
 ### 1.2.3 (2021-12-20)
 #### Key Bug Fixes
 * Upgraded log4j2 to 2.17.0 to address the security vulnerability

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.azure.cosmos.kafka</groupId>
     <artifactId>kafka-connect-cosmos</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
 
     <name> kafka-connect-cosmos</name>
     <url>https://github.com/microsoft/kafka-connect-cosmosdb</url>


### PR DESCRIPTION
releasing 1.2.4 which has 2.17.1 log4j2  addressing
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832