### PR TITLE
Added tolerance into CosmosDBSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ For more information on the performance tests run for the Sink and Source connec
 
 Refer to the [Performance Environment Setup](./src/perf/README.md) for exact steps on deploying the performance test environment for the Connectors.
 
+## Dead Letter Queue
+We introduced the standard dead level queue from Kafka. For more info see: https://www.confluent.io/blog/kafka-connect-deep-dive-error-handling-dead-letter-queues
+
 ## Resources
 
 - [Kafka Connect](http://kafka.apache.org/documentation.html#connect)

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <kafka.version>2.7.0</kafka.version>
+        <kafka.version>2.8.1</kafka.version>
         <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -28,9 +28,9 @@ public class CosmosDBConfig extends AbstractConfig {
     private static final String COSMOS_DATABASE_NAME_DISPLAY = "Cosmos Database name";
 
     public static final String COSMOS_CONTAINER_TOPIC_MAP_CONF = "connect.cosmos.containers.topicmap";
-    private static final String COSMOS_CONTAINER_TOPIC_MAP_DOC = 
-        "A comma delimited list of Kafka topics mapped to Cosmos containers.\n" 
-        + "For example: topic1#con1,topic2#con2.";
+    private static final String COSMOS_CONTAINER_TOPIC_MAP_DOC =
+            "A comma delimited list of Kafka topics mapped to Cosmos containers.\n"
+                    + "For example: topic1#con1,topic2#con2.";
     private static final String COSMOS_CONTAINER_TOPIC_MAP_DISPLAY = "Topic-Container map";
 
     public static final String  COSMOS_PROVIDER_NAME_CONF = "connect.cosmos.provider.name";
@@ -41,7 +41,7 @@ public class CosmosDBConfig extends AbstractConfig {
 
     public static final String TOLERANCE_ON_ERROR_CONFIG = "tolerance.error";
     public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. None for failing on error. All for log and continue";
-    
+
     private String connEndpoint;
     private String connKey;
     private String databaseName;
@@ -64,7 +64,7 @@ public class CosmosDBConfig extends AbstractConfig {
 
     public static ConfigDef getConfig() {
         ConfigDef result = new ConfigDef();
-        
+
         defineConnectionConfigs(result);
         defineDatabaseConfigs(result);
 
@@ -74,77 +74,77 @@ public class CosmosDBConfig extends AbstractConfig {
     private static void defineConnectionConfigs(ConfigDef result) {
         final String connectionGroupName = "Connection";
         int connectionGroupOrder = 0;
-        
+
         result
-            .define(
-                COSMOS_CONN_ENDPOINT_CONF,
-                Type.STRING,
-                ConfigDef.NO_DEFAULT_VALUE,
-                NON_EMPTY_STRING,
-                Importance.HIGH,
-                COSMOS_CONN_ENDPOINT_DOC,
-                connectionGroupName,
-                connectionGroupOrder++,
-                Width.LONG,
-                COSMOS_CONN_ENDPOINT_DISPLAY
-            )
-            .define(
-                COSMOS_CONN_KEY_CONF,
-                Type.PASSWORD,
-                ConfigDef.NO_DEFAULT_VALUE,
-                Importance.HIGH,
-                COSMOS_CONN_KEY_DOC,
-                connectionGroupName,
-                connectionGroupOrder++,
-                Width.LONG,
-                COSMOS_CONN_KEY_DISPLAY
-            ).define(
-                TOLERANCE_ON_ERROR_CONFIG,
-                Type.STRING,
-                "None",
-                Importance.MEDIUM,
-                TOLERANCE_ON_ERROR_DOC
-            )
-            .defineInternal(
-                COSMOS_PROVIDER_NAME_CONF, 
-                Type.STRING, 
-                COSMOS_PROVIDER_NAME_DEFAULT,
-                Importance.LOW        
-            );
+                .define(
+                        COSMOS_CONN_ENDPOINT_CONF,
+                        Type.STRING,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        NON_EMPTY_STRING,
+                        Importance.HIGH,
+                        COSMOS_CONN_ENDPOINT_DOC,
+                        connectionGroupName,
+                        connectionGroupOrder++,
+                        Width.LONG,
+                        COSMOS_CONN_ENDPOINT_DISPLAY
+                )
+                .define(
+                        COSMOS_CONN_KEY_CONF,
+                        Type.PASSWORD,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        Importance.HIGH,
+                        COSMOS_CONN_KEY_DOC,
+                        connectionGroupName,
+                        connectionGroupOrder++,
+                        Width.LONG,
+                        COSMOS_CONN_KEY_DISPLAY
+                ).define(
+                        TOLERANCE_ON_ERROR_CONFIG,
+                        Type.STRING,
+                        "None",
+                        Importance.MEDIUM,
+                        TOLERANCE_ON_ERROR_DOC
+                )
+                .defineInternal(
+                        COSMOS_PROVIDER_NAME_CONF,
+                        Type.STRING,
+                        COSMOS_PROVIDER_NAME_DEFAULT,
+                        Importance.LOW
+                );
     }
 
     private static void defineDatabaseConfigs(ConfigDef result) {
         final String databaseGroupName = "Database";
         int databaseGroupOrder = 0;
-        
+
         // When adding new config defines below, update COSMOS_DATABASE_GROUP_ORDER
         // This way, the source/sink configs will resume order from the right position.
 
         result
-            .define(
-                COSMOS_DATABASE_NAME_CONF,
-                Type.STRING,
-                ConfigDef.NO_DEFAULT_VALUE,
-                NON_EMPTY_STRING,
-                Importance.HIGH,
-                COSMOS_DATABASE_NAME_DOC,
-                databaseGroupName,
-                databaseGroupOrder++,
-                Width.MEDIUM,
-                COSMOS_DATABASE_NAME_DISPLAY
-            )
-            .define(
-                COSMOS_CONTAINER_TOPIC_MAP_CONF,
-                Type.STRING,
-                ConfigDef.NO_DEFAULT_VALUE,
-                NON_EMPTY_STRING,
-                Importance.HIGH,
-                COSMOS_CONTAINER_TOPIC_MAP_DOC,
-                databaseGroupName,
-                databaseGroupOrder++,
-                Width.MEDIUM,
-                COSMOS_CONTAINER_TOPIC_MAP_DISPLAY
-            );
+                .define(
+                        COSMOS_DATABASE_NAME_CONF,
+                        Type.STRING,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        NON_EMPTY_STRING,
+                        Importance.HIGH,
+                        COSMOS_DATABASE_NAME_DOC,
+                        databaseGroupName,
+                        databaseGroupOrder++,
+                        Width.MEDIUM,
+                        COSMOS_DATABASE_NAME_DISPLAY
+                )
+                .define(
+                        COSMOS_CONTAINER_TOPIC_MAP_CONF,
+                        Type.STRING,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        NON_EMPTY_STRING,
+                        Importance.HIGH,
+                        COSMOS_CONTAINER_TOPIC_MAP_DOC,
+                        databaseGroupName,
+                        databaseGroupOrder++,
+                        Width.MEDIUM,
+                        COSMOS_CONTAINER_TOPIC_MAP_DISPLAY
+                );
     }
 
     public String getConnEndpoint() {

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -20,8 +20,8 @@ public class CosmosDBConfig extends AbstractConfig {
     public static final String COSMOS_PROVIDER_NAME_CONF = "connect.cosmos.provider.name";
     public static final int COSMOS_DATABASE_GROUP_ORDER = 2;
     public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
-    public static final String TOLERANCE_ON_ERROR_CONFIG = "tolerance.error";
-    public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. None for failing on error. All for log and continue";
+    public static final String TOLERANCE_ON_ERROR_CONFIG = "errors.tolerance";
+    public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. 'none' for failing on error. 'all' for log and continue";
     private static final Validator NON_EMPTY_STRING = new NonEmptyString();
     private static final String COSMOS_CONN_ENDPOINT_DOC = "Cosmos endpoint URL.";
     private static final String COSMOS_CONN_ENDPOINT_DISPLAY = "Cosmos Endpoint";
@@ -93,7 +93,7 @@ public class CosmosDBConfig extends AbstractConfig {
                 ).define(
                         TOLERANCE_ON_ERROR_CONFIG,
                         Type.STRING,
-                        "None",
+                        "none",
                         Importance.MEDIUM,
                         TOLERANCE_ON_ERROR_DOC
                 )

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -38,6 +38,9 @@ public class CosmosDBConfig extends AbstractConfig {
 
     public static final int COSMOS_DATABASE_GROUP_ORDER = 2;
     public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
+
+    public static final String TOLERANCE_ON_ERROR_CONFIG = "tolerance.error";
+    public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. None for failing on error. All for log and continue";
     
     private String connEndpoint;
     private String connKey;
@@ -95,6 +98,12 @@ public class CosmosDBConfig extends AbstractConfig {
                 connectionGroupOrder++,
                 Width.LONG,
                 COSMOS_CONN_KEY_DISPLAY
+            ).define(
+                TOLERANCE_ON_ERROR_CONFIG,
+                Type.STRING,
+                "None",
+                Importance.MEDIUM,
+                TOLERANCE_ON_ERROR_DOC
             )
             .defineInternal(
                 COSMOS_PROVIDER_NAME_CONF, 

--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -11,37 +11,29 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
 
-@SuppressWarnings ({"squid:S1854", "squid:S2160"})  // suppress unneeded int *groupOrder variables, equals method
+@SuppressWarnings({"squid:S1854", "squid:S2160"})  // suppress unneeded int *groupOrder variables, equals method
 public class CosmosDBConfig extends AbstractConfig {
-    private static final Validator NON_EMPTY_STRING = new NonEmptyString();
-    
     public static final String COSMOS_CONN_ENDPOINT_CONF = "connect.cosmos.connection.endpoint";
+    public static final String COSMOS_CONN_KEY_CONF = "connect.cosmos.master.key";
+    public static final String COSMOS_DATABASE_NAME_CONF = "connect.cosmos.databasename";
+    public static final String COSMOS_CONTAINER_TOPIC_MAP_CONF = "connect.cosmos.containers.topicmap";
+    public static final String COSMOS_PROVIDER_NAME_CONF = "connect.cosmos.provider.name";
+    public static final int COSMOS_DATABASE_GROUP_ORDER = 2;
+    public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
+    public static final String TOLERANCE_ON_ERROR_CONFIG = "tolerance.error";
+    public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. None for failing on error. All for log and continue";
+    private static final Validator NON_EMPTY_STRING = new NonEmptyString();
     private static final String COSMOS_CONN_ENDPOINT_DOC = "Cosmos endpoint URL.";
     private static final String COSMOS_CONN_ENDPOINT_DISPLAY = "Cosmos Endpoint";
-
-    public static final String COSMOS_CONN_KEY_CONF = "connect.cosmos.master.key";
     private static final String COSMOS_CONN_KEY_DOC = "Cosmos connection master (primary) key.";
     private static final String COSMOS_CONN_KEY_DISPLAY = "Cosmos Connection Key";
-
-    public static final String COSMOS_DATABASE_NAME_CONF = "connect.cosmos.databasename";
     private static final String COSMOS_DATABASE_NAME_DOC = "Cosmos target database to write records into.";
     private static final String COSMOS_DATABASE_NAME_DISPLAY = "Cosmos Database name";
-
-    public static final String COSMOS_CONTAINER_TOPIC_MAP_CONF = "connect.cosmos.containers.topicmap";
     private static final String COSMOS_CONTAINER_TOPIC_MAP_DOC =
             "A comma delimited list of Kafka topics mapped to Cosmos containers.\n"
                     + "For example: topic1#con1,topic2#con2.";
     private static final String COSMOS_CONTAINER_TOPIC_MAP_DISPLAY = "Topic-Container map";
-
-    public static final String  COSMOS_PROVIDER_NAME_CONF = "connect.cosmos.provider.name";
     private static final String COSMOS_PROVIDER_NAME_DEFAULT = null;
-
-    public static final int COSMOS_DATABASE_GROUP_ORDER = 2;
-    public static final String COSMOS_CLIENT_USER_AGENT_SUFFIX = "APN/1.0 Microsoft/1.0 KafkaConnect/";
-
-    public static final String TOLERANCE_ON_ERROR_CONFIG = "tolerance.error";
-    public static final String TOLERANCE_ON_ERROR_DOC = "Tolerance level. None for failing on error. All for log and continue";
-
     private String connEndpoint;
     private String connKey;
     private String databaseName;

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -91,8 +91,8 @@ public class CosmosDBSinkTask extends SinkTask {
                     addItemToContainer(container, recordValue);
                 } catch (BadRequestException bre) {
                     if (config.getString(TOLERANCE_ON_ERROR_CONFIG).equalsIgnoreCase("all")) {
-                        logger.error("Could not upload record to CosmosDb, but tolerance is set to all. Value: {},"
-                                + " error: {}", recordValue.toString(), bre.getMessage());
+                        logger.error("Could not upload record to CosmosDb, but tolerance is set to all. Value: {}."
+                                + " Error: {}", recordValue.toString(), bre.getMessage());
                     } else {
                         throw new CosmosDBWriteException(record, bre);
                     }

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -91,8 +91,8 @@ public class CosmosDBSinkTask extends SinkTask {
                     addItemToContainer(container, recordValue);
                 } catch (BadRequestException bre) {
                     if (config.getString(TOLERANCE_ON_ERROR_CONFIG).equalsIgnoreCase("all")) {
-                        logger.error("Could not upload record to CosmosDb, but tolerance is set to all. Value: {}," +
-                                " error: {}", recordValue.toString(), bre.getMessage());
+                        logger.error("Could not upload record to CosmosDb, but tolerance is set to all. Value: {},"
+                                + " error: {}", recordValue.toString(), bre.getMessage());
                     } else {
                         throw new CosmosDBWriteException(record, bre);
                     }

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -1,5 +1,10 @@
 package com.azure.cosmos.kafka.connect.sink;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
@@ -7,11 +12,6 @@ import com.azure.cosmos.implementation.BadRequestException;
 import com.azure.cosmos.kafka.connect.CosmosDBConfig;
 import com.azure.cosmos.kafka.connect.sink.id.strategy.AbstractIdStrategyConfig;
 import com.azure.cosmos.kafka.connect.sink.id.strategy.IdStrategy;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.kafka.connect.data.Struct;
@@ -84,6 +84,7 @@ public class CosmosDBSinkTask extends SinkTask {
                 try {
                     addItemToContainer(container, recordValue);
                 } catch (BadRequestException bre) {
+                    if (config.getString(TOLERANCE_ON_ERROR_CONFIG))
                     throw new CosmosDBWriteException(record, bre);
                 }
             }

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.implementation.BadRequestException;
 import com.azure.cosmos.kafka.connect.CosmosDBConfig;
 import com.azure.cosmos.kafka.connect.sink.id.strategy.AbstractIdStrategyConfig;
@@ -15,6 +16,7 @@ import com.azure.cosmos.kafka.connect.sink.id.strategy.IdStrategy;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -89,7 +91,7 @@ public class CosmosDBSinkTask extends SinkTask {
 
                 try {
                     addItemToContainer(container, recordValue);
-                } catch (BadRequestException bre) {
+                } catch (CosmosException | ConnectException bre) {
                     if (config.getString(TOLERANCE_ON_ERROR_CONFIG).equalsIgnoreCase("all")) {
                         logger.error("Could not upload record to CosmosDb, but tolerance is set to all. Value: {}."
                                 + " Error: {}", recordValue.toString(), bre.getMessage());

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTestNotFails.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTestNotFails.java
@@ -13,13 +13,17 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertNotNull;
@@ -33,6 +37,8 @@ public class CosmosDBSinkTaskTestNotFails {
     private CosmosDBSinkTask testTask;
     private CosmosClient mockCosmosClient;
     private CosmosContainer mockContainer;
+    private SinkTaskContext mockContext = Mockito.mock(SinkTaskContext.class);
+    private ErrantRecordReporter mockErrantReporter = Mockito.mock(ErrantRecordReporter.class);
 
     @Before
     public void setup() throws IllegalAccessException {
@@ -42,7 +48,7 @@ public class CosmosDBSinkTaskTestNotFails {
         Map<String, String> settingAssignment = CosmosDBSinkConfigTest.setupConfigs();
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, topicName + "#" + containerName);
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, databaseName);
-        settingAssignment.put(CosmosDBSinkConfig.TOLERANCE_ON_ERROR_CONFIG, "All");
+        settingAssignment.put(CosmosDBSinkConfig.TOLERANCE_ON_ERROR_CONFIG, "all");
         CosmosDBSinkConfig config = new CosmosDBSinkConfig(settingAssignment);
         FieldUtils.writeField(testTask, "config", config, true);
 
@@ -52,20 +58,35 @@ public class CosmosDBSinkTaskTestNotFails {
         when(mockCosmosClient.getDatabase(anyString())).thenReturn(mockDatabase);
         mockContainer = Mockito.mock(CosmosContainer.class);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
+        when(mockContext.errantRecordReporter()).thenReturn(mockErrantReporter);
 
         FieldUtils.writeField(testTask, "client", mockCosmosClient, true);
+
     }
-    
+    @After()
+    public void resetContext() throws IllegalAccessException {
+        FieldUtils.writeField(testTask,  "context", null, true);
+    }
+
 
     @Test
-    public void testPutMapThatFailsDoesNotStopTask() throws JsonProcessingException {
+    public void testPutMapThatFailsDoesNotStopTask() throws JsonProcessingException, IllegalAccessException {
+
         Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
         Schema mapSchema = new ConnectSchema(Schema.Type.MAP);
         when(mockContainer.upsertItem(any())).thenThrow(new BadRequestException("Something"));
         SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", mapSchema, "{", 0L);
-
-        testTask.put(Arrays.asList(record));
-
+        testTask.put(List.of(record));
+    }
+    @Test
+    public void testPutMapThatFailsDoesNotStopTaskWithdlq() throws JsonProcessingException, IllegalAccessException {
+        FieldUtils.writeField(testTask,  "context", mockContext, true);
+        Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
+        Schema mapSchema = new ConnectSchema(Schema.Type.MAP);
+        when(mockContainer.upsertItem(any())).thenThrow(new BadRequestException("Something"));
+        SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", mapSchema, "{", 0L);
+        testTask.put(List.of(record));
+        verify(mockContext.errantRecordReporter(), times(1)).report(any(), any());
     }
 }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTestNotFails.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTestNotFails.java
@@ -26,7 +26,7 @@ import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.fail;
 import static org.mockito.Mockito.*;
 
-public class CosmosDBSinkTaskTest {
+public class CosmosDBSinkTaskTestNotFails {
     private final String topicName = "testtopic";
     private final String containerName = "container666";
     private final String databaseName = "fakeDatabase312";
@@ -42,6 +42,7 @@ public class CosmosDBSinkTaskTest {
         Map<String, String> settingAssignment = CosmosDBSinkConfigTest.setupConfigs();
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_CONTAINER_TOPIC_MAP_CONF, topicName + "#" + containerName);
         settingAssignment.put(CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, databaseName);
+        settingAssignment.put(CosmosDBSinkConfig.TOLERANCE_ON_ERROR_CONFIG, "All");
         CosmosDBSinkConfig config = new CosmosDBSinkConfig(settingAssignment);
         FieldUtils.writeField(testTask, "config", config, true);
 
@@ -54,50 +55,17 @@ public class CosmosDBSinkTaskTest {
 
         FieldUtils.writeField(testTask, "client", mockCosmosClient, true);
     }
+    
 
     @Test
-    public void testPutPlainTextString() {
-        Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
-
-        SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", stringSchema, "foo", 0L);
-        assertNotNull(record.value());
-
-        //Make mock connector to serialize a non-JSON payload
-        when(mockContainer.upsertItem(any())).then((invocation) -> {
-            Object item = invocation.getArgument(0);
-            //Will throw exception:
-            try {
-                JsonNode jsonNode = new ObjectMapper().readTree(item.toString());
-                assertNotNull(jsonNode);
-                return null;
-            } catch (JsonParseException jpe) {
-                throw new BadRequestException("Unable to serialize JSON request", jpe);
-            }
-        });
-
-        try {
-            testTask.put(Arrays.asList(record));
-            fail("Expected ConnectException on bad message");
-        } catch (ConnectException ce) {
-
-        } catch (Throwable t) {
-            fail("Expected ConnectException, but got: " + t.getClass().getName());
-        }
-
-        verify(mockContainer, times(1)).upsertItem("foo");
-    }
-
-    @Test
-    public void testPutMap() {
+    public void testPutMapThatFailsDoesNotStopTask() throws JsonProcessingException {
         Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
         Schema mapSchema = new ConnectSchema(Schema.Type.MAP);
-        Map<String, String> map = new HashMap<>();
-        map.put("foo", "baaarrrrrgh");
+        when(mockContainer.upsertItem(any())).thenThrow(new BadRequestException("Something"));
+        SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", mapSchema, "{", 0L);
 
-        SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", mapSchema, map, 0L);
-        assertNotNull(record.value());
         testTask.put(Arrays.asList(record));
-        verify(mockContainer, times(1)).upsertItem(map);
+
     }
 }
 


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
The problem with the current implementation is that one record throws an exception then the connector fails. On Kafka once the record is written it cannot be deleted. So we need a way to skip this record. 
## Observability + Testing
- What changes or considerations did you make in relation to observability?
If a Record that we defined as Key is null we get the following error: "The input name '' is invalid. Ensure to provide a unique non-empty string less than '1024' characters." And the connector fails. 

- Did you add testing to account for any new or changed work?
I added a configuration that ensures that if processing fails we log the failed record and continue processing the rest of the stream. 

## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
