### PR TITLE
Fixed sink bug when using struct type for record value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>6.0.1</version>

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -111,12 +111,26 @@ public class CosmosDBSinkTask extends SinkTask {
                 Object recordValue;
                 if (record.value() instanceof Struct) {
                     recordValue = StructToJsonMap.toJsonMap((Struct) record.value());
+                    //  TODO: Do we need to update the value schema to map or keep it struct?
                 } else {
                     recordValue = record.value();
                 }
 
                 maybeInsertId(recordValue, record);
-                toBeWrittenRecordList.add(record);
+
+                //  Create an updated record with from the current record and the updated record value
+                final SinkRecord updatedRecord = new SinkRecord(record.topic(),
+                    record.kafkaPartition(),
+                    record.keySchema(),
+                    record.key(),
+                    record.valueSchema(),
+                    recordValue,
+                    record.kafkaOffset(),
+                    record.timestamp(),
+                    record.timestampType(),
+                    record.headers());
+
+                toBeWrittenRecordList.add(updatedRecord);
             }
 
             try {

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkConnectorTest.java
@@ -4,12 +4,12 @@
 package com.azure.cosmos.kafka.connect.sink;
 
 import com.azure.cosmos.kafka.connect.CosmosDBConfig.CosmosClientBuilder;
-import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -25,7 +25,7 @@ public class CosmosDBSinkConnectorTest {
 
   @Test
   public void testValidateEmptyConfigFailsRequiredFields() {
-    Config config = new CosmosDBSinkConnector().validate(ImmutableMap.of());
+    Config config = new CosmosDBSinkConnector().validate(Collections.emptyMap());
 
     Map<String, List<String>> errorMessages = config.configValues().stream()
         .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
@@ -46,7 +46,7 @@ public class CosmosDBSinkConnectorTest {
           .when(() -> CosmosClientBuilder.createClient(anyString(), anyString()))
           .thenThrow(IllegalArgumentException.class);
 
-      Config config = connector.validate(ImmutableMap.of(
+      Config config = connector.validate(Map.of(
           CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
           CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
           CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",
@@ -71,7 +71,7 @@ public class CosmosDBSinkConnectorTest {
           .then(answerVoid((s1, s2) -> {
           }));
 
-      Config config = connector.validate(ImmutableMap.of(
+      Config config = connector.validate(Map.of(
           CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF,
           "https://cosmos-instance.documents.azure.com:443/",
           CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
@@ -106,7 +106,7 @@ public class CosmosDBSinkConnectorTest {
   }
 
   private void invalidTopicMapString(CosmosDBSinkConnector connector, String topicMapConfig) {
-    Config config = connector.validate(ImmutableMap.of(
+    Config config = connector.validate(Map.of(
         CosmosDBSinkConfig.COSMOS_CONN_ENDPOINT_CONF, "https://endpoint:port/",
         CosmosDBSinkConfig.COSMOS_CONN_KEY_CONF, "superSecretPassword",
         CosmosDBSinkConfig.COSMOS_DATABASE_NAME_CONF, "superAwesomeDatabase",

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTaskTest.java
@@ -7,6 +7,9 @@ import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.implementation.BadRequestException;
+import com.azure.cosmos.kafka.connect.source.JsonToStruct;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Schema;
@@ -23,9 +26,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -108,7 +113,7 @@ public class CosmosDBSinkTaskTest {
             }
 
             try {
-                testTask.put(Arrays.asList(record));
+                testTask.put(List.of(record));
                 fail("Expected ConnectException on bad message");
             } catch (ConnectException ce) {
 
@@ -158,7 +163,7 @@ public class CosmosDBSinkTaskTest {
             }
 
             try {
-                testTask.put(Arrays.asList(record));
+                testTask.put(List.of(record));
             } catch (ConnectException ce) {
                 fail("Expected sink write succeeded. but got: " + ce.getMessage());
             } catch (Throwable t) {
@@ -171,6 +176,84 @@ public class CosmosDBSinkTaskTest {
                 mockedWriterConstruction.close();
             }
         }
+    }
+
+    @Test
+    public void sinkWriteSucceededWithStructRecordValue() {
+        Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
+        Schema structSchema = new ConnectSchema(Schema.Type.STRUCT);
+        ObjectNode objectNode = new ObjectNode(new JsonNodeFactory(false))
+            .put("foo", "fooz")
+            .put("bar", "baaz");
+        JsonToStruct jsonToStruct = new JsonToStruct();
+
+        Object recordValue = jsonToStruct.recordToSchemaAndValue(objectNode).value();
+
+
+        SinkRecord record = new SinkRecord(topicName, 1, stringSchema, "nokey", structSchema, recordValue, 0L);
+        assertNotNull(record.value());
+
+        SinkWriteResponse sinkWriteResponse = new SinkWriteResponse();
+        sinkWriteResponse.getSucceededRecords().add(record);
+
+        MockedConstruction<? extends SinkWriterBase> mockedWriterConstruction = null;
+        AtomicReference<List<SinkRecord>> sinkRecords = new AtomicReference<>();
+        try {
+            if (this.isBulkModeEnabled) {
+                mockedWriterConstruction = mockConstructionWithAnswer(BulkWriter.class, invocation -> {
+                    if (invocation.getMethod().equals(BulkWriter.class.getMethod("write", List.class))) {
+                        sinkRecords.set(invocation.getArgument(0));
+                        return sinkWriteResponse;
+                    }
+
+                    throw new IllegalStateException("Not implemented for method " + invocation.getMethod().getName());
+                });
+            } else {
+                mockedWriterConstruction = mockConstructionWithAnswer(PointWriter.class, invocation -> {
+                    if (invocation.getMethod().equals(PointWriter.class.getMethod("write", List.class))) {
+                        sinkRecords.set(invocation.getArgument(0));
+                        return sinkWriteResponse;
+                    }
+
+                    throw new IllegalStateException("Not implemented for method " + invocation.getMethod().getName());
+                });
+            }
+
+            try {
+                testTask.put(List.of(record));
+            } catch (ConnectException ce) {
+                fail("Expected sink write succeeded. but got: " + ce.getMessage());
+            } catch (Throwable t) {
+                fail("Expected sink write succeeded, but got: " + t.getClass().getName());
+            }
+
+            assertEquals(1, mockedWriterConstruction.constructed().size());
+
+            SinkRecord sinkRecord = sinkRecords.get().get(0);
+            assertRecordEquals(record, sinkRecord);
+
+            Object value = sinkRecord.value();
+            assertTrue(value instanceof Map);
+
+            assertEquals("fooz", ((Map<?, ?>) value).get("foo"));
+            assertEquals("baaz", ((Map<?, ?>) value).get("bar"));
+        } finally {
+            if (mockedWriterConstruction != null) {
+                mockedWriterConstruction.close();
+            }
+        }
+    }
+
+    private void assertRecordEquals(SinkRecord record, SinkRecord updatedRecord) {
+        assertEquals(record.kafkaOffset(), updatedRecord.kafkaOffset());
+        assertEquals(record.timestamp(), updatedRecord.timestamp());
+        assertEquals(record.timestampType(), updatedRecord.timestampType());
+        assertEquals(record.headers(), updatedRecord.headers());
+        assertEquals(record.keySchema(), updatedRecord.keySchema());
+        assertEquals(record.valueSchema(), updatedRecord.valueSchema());
+        assertEquals(record.key(), updatedRecord.key());
+        assertEquals(record.topic(), updatedRecord.topic());
+        assertEquals(record.kafkaPartition(), updatedRecord.kafkaPartition());
     }
 }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/StructToJsonMapTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/StructToJsonMapTest.java
@@ -3,8 +3,6 @@
 
 package com.azure.cosmos.kafka.connect.sink;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -28,7 +26,7 @@ public class StructToJsonMapTest {
         Schema schema = SchemaBuilder.struct()
                 .build();
         Struct struct = new Struct(schema);
-        assertEquals(ImmutableMap.of(), StructToJsonMap.toJsonMap(struct));
+        assertEquals(Map.of(), StructToJsonMap.toJsonMap(struct));
     }
 
 
@@ -38,10 +36,10 @@ public class StructToJsonMapTest {
                 .field("array_of_boolean", SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).build());
 
         Struct struct = new Struct(schema)
-                .put("array_of_boolean", ImmutableList.of());
+                .put("array_of_boolean", Map.of());
 
         Map<String, Object> converted = StructToJsonMap.toJsonMap(struct);
-        assertEquals(ImmutableList.of(), ((List<Boolean>) converted.get("array_of_boolean")));
+        assertEquals(List.of(), converted.get("array_of_boolean"));
     }
 
     @Test
@@ -86,8 +84,8 @@ public class StructToJsonMapTest {
                 .put("string", quickBrownFox)
                 .put("struct", new Struct(embeddedSchema)
                         .put("embedded_string", quickBrownFox))
-                .put("array_of_boolean", ImmutableList.of(false))
-                .put("array_of_struct", ImmutableList.of(
+                .put("array_of_boolean", List.of(false))
+                .put("array_of_struct", List.of(
                         new Struct(embeddedSchema).put("embedded_string", quickBrownFox)));
 
         Map<String, Object> converted = StructToJsonMap.toJsonMap(struct);
@@ -105,7 +103,7 @@ public class StructToJsonMapTest {
         assertEquals(quickBrownFox, converted.get("string"));
         assertEquals(quickBrownFox, ((Map<String, Object>) converted.get("struct")).get("embedded_string"));
         assertEquals(false, ((List<Boolean>) converted.get("array_of_boolean")).get(0));
-        assertEquals(ImmutableMap.of("embedded_string", quickBrownFox), ((List<Struct>) converted.get("array_of_struct")).get(0));
+        assertEquals(Map.of("embedded_string", quickBrownFox), ((List<Struct>) converted.get("array_of_struct")).get(0));
         assertNull(converted.get("optional_string"));
     }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/StructToJsonMapTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/StructToJsonMapTest.java
@@ -36,7 +36,7 @@ public class StructToJsonMapTest {
                 .field("array_of_boolean", SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).build());
 
         Struct struct = new Struct(schema)
-                .put("array_of_boolean", Map.of());
+                .put("array_of_boolean", List.of());
 
         Map<String, Object> converted = StructToJsonMap.toJsonMap(struct);
         assertEquals(List.of(), converted.get("array_of_boolean"));

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/ProvidedInStrategyTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/ProvidedInStrategyTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -158,15 +159,15 @@ public class ProvidedInStrategyTest {
 
     @Test
     public void complexJsonPath() {
-        returnOnKeyOrValue(null,
-            Map.of("id", List.of(
-                Map.of("id", 0,
-                    "name", "cosmos kramer",
-                    "occupation", "unknown"),
-                Map.of("id", 1,
-                    "name", "franz kafka",
-                    "occupation", "writer")
-            )));
+        Map<String, Object> map1 = new LinkedHashMap<>();
+        map1.put("id", 0);
+        map1.put("name", "cosmos kramer");
+        map1.put("occupation", "unknown");
+        Map<String, Object> map2 = new LinkedHashMap<>();
+        map2.put("id", 1);
+        map2.put("name", "franz kafka");
+        map2.put("occupation", "writer");
+        returnOnKeyOrValue(null, Map.of("id", List.of(map1, map2)));
 
         strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[0].name"));
         assertEquals("cosmos kramer", strategy.generateId(record));

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/ProvidedInStrategyTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/ProvidedInStrategyTest.java
@@ -3,8 +3,6 @@
 
 package com.azure.cosmos.kafka.connect.sink.id.strategy;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -16,6 +14,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -24,7 +25,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class ProvidedInStrategyTest {
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> parameters() {
-        return ImmutableList.of(
+        return List.of(
                 new Object[]{ProvidedInValueStrategy.class, new ProvidedInValueStrategy()},
                 new Object[]{ProvidedInKeyStrategy.class, new ProvidedInKeyStrategy()}
         );
@@ -43,7 +44,7 @@ public class ProvidedInStrategyTest {
     public void setUp() {
         initMocks(this);
 
-        strategy.configure(ImmutableMap.of());
+        strategy.configure(Map.of());
     }
 
     private void returnOnKeyOrValue(Schema schema, Object ret) {
@@ -64,13 +65,13 @@ public class ProvidedInStrategyTest {
 
     @Test(expected = ConnectException.class)
     public void noIdInValueShouldFail() {
-        returnOnKeyOrValue(null, ImmutableMap.of());
+        returnOnKeyOrValue(null, Map.of());
         strategy.generateId(record);
     }
 
     @Test
     public void stringIdOnMapShouldReturn() {
-        returnOnKeyOrValue(null, ImmutableMap.of(
+        returnOnKeyOrValue(null, Map.of(
                 "id", "1234567"
         ));
         assertEquals("1234567", strategy.generateId(record));
@@ -78,7 +79,7 @@ public class ProvidedInStrategyTest {
 
     @Test
     public void nonStringIdOnMapShouldReturn() {
-        returnOnKeyOrValue(null, ImmutableMap.of(
+        returnOnKeyOrValue(null, Map.of(
                 "id", 1234567
         ));
         assertEquals("1234567", strategy.generateId(record));
@@ -113,7 +114,7 @@ public class ProvidedInStrategyTest {
 
     @Test
     public void jsonPathOnStruct() {
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.name"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.name"));
 
         Schema idSchema = SchemaBuilder.struct()
             .field("name", Schema.STRING_SCHEMA)
@@ -130,27 +131,27 @@ public class ProvidedInStrategyTest {
 
     @Test
     public void jsonPathOnMap() {
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.name"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.name"));
         returnOnKeyOrValue(null,
-            ImmutableMap.of("id", ImmutableMap.of("name", "franz kafka")));
+            Map.of("id", Map.of("name", "franz kafka")));
 
         assertEquals("franz kafka", strategy.generateId(record));
     }
 
     @Test(expected = ConnectException.class)
     public void invalidJsonPathThrows() {
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "invalid.path"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "invalid.path"));
         returnOnKeyOrValue(null,
-            ImmutableMap.of("id", ImmutableMap.of("name", "franz kafka")));
+            Map.of("id", Map.of("name", "franz kafka")));
 
         strategy.generateId(record);
     }
 
     @Test(expected = ConnectException.class)
     public void jsonPathNotExistThrows() {
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.not.exist"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id.not.exist"));
         returnOnKeyOrValue(null,
-            ImmutableMap.of("id", ImmutableMap.of("name", "franz kafka")));
+            Map.of("id", Map.of("name", "franz kafka")));
 
         strategy.generateId(record);
     }
@@ -158,25 +159,25 @@ public class ProvidedInStrategyTest {
     @Test
     public void complexJsonPath() {
         returnOnKeyOrValue(null,
-            ImmutableMap.of("id", ImmutableList.of(
-                ImmutableMap.of("id", 0,
+            Map.of("id", List.of(
+                Map.of("id", 0,
                     "name", "cosmos kramer",
                     "occupation", "unknown"),
-                ImmutableMap.of("id", 1,
+                Map.of("id", 1,
                     "name", "franz kafka",
                     "occupation", "writer")
             )));
 
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[0].name"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[0].name"));
         assertEquals("cosmos kramer", strategy.generateId(record));
 
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[1].name"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[1].name"));
         assertEquals("franz kafka", strategy.generateId(record));
 
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[*].id"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id[*].id"));
         assertEquals("[0,1]", strategy.generateId(record));
 
-        strategy.configure(ImmutableMap.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id"));
+        strategy.configure(Map.of(ProvidedInConfig.JSON_PATH_CONFIG, "$.id"));
         assertEquals(
             "[{\"id\":0,\"name\":\"cosmos kramer\",\"occupation\":\"unknown\"},{\"id\":1,\"name\":\"franz kafka\",\"occupation\":\"writer\"}]",
             strategy.generateId(record));
@@ -184,7 +185,7 @@ public class ProvidedInStrategyTest {
 
     @Test
     public void generatedIdSanitized() {
-        returnOnKeyOrValue(null, ImmutableMap.of("id", "#my/special\\id?"));
+        returnOnKeyOrValue(null, Map.of("id", "#my/special\\id?"));
 
         String id = strategy.generateId(record);
         assertEquals("_my_special_id_", id);

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/TemplateStrategyTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/id/strategy/TemplateStrategyTest.java
@@ -3,12 +3,13 @@
 
 package com.azure.cosmos.kafka.connect.sink.id.strategy;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -19,7 +20,7 @@ public class TemplateStrategyTest {
 
     @Test
     public void simpleKey() {
-        strategy.configure(ImmutableMap.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${key}"));
+        strategy.configure(Map.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${key}"));
         SinkRecord record = mock(SinkRecord.class);
         when(record.keySchema()).thenReturn(Schema.STRING_SCHEMA);
         when(record.key()).thenReturn("test");
@@ -30,7 +31,7 @@ public class TemplateStrategyTest {
 
     @Test
     public void kafkaMetadata() {
-        strategy.configure(ImmutableMap.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${topic}-${partition}-${offset}"));
+        strategy.configure(Map.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${topic}-${partition}-${offset}"));
         SinkRecord record = mock(SinkRecord.class);
         when(record.topic()).thenReturn("mytopic");
         when(record.kafkaPartition()).thenReturn(0);
@@ -42,14 +43,14 @@ public class TemplateStrategyTest {
 
     @Test
     public void unknownVariablePreserved() {
-        strategy.configure(ImmutableMap.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${unknown}"));
+        strategy.configure(Map.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${unknown}"));
         String id = strategy.generateId(mock(SinkRecord.class));
         assertEquals("${unknown}", id);
     }
 
     @Test
     public void nestedStruct() {
-        strategy.configure(ImmutableMap.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${key}"));
+        strategy.configure(Map.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "${key}"));
         SinkRecord record = mock(SinkRecord.class);
         Schema nestedSchema = SchemaBuilder.struct()
                 .field("nested_field", Schema.STRING_SCHEMA)
@@ -74,7 +75,7 @@ public class TemplateStrategyTest {
     @Test
     public void fullKeyStrategyUsesFullKey() {
         strategy = new FullKeyStrategy();
-        strategy.configure(ImmutableMap.of());
+        strategy.configure(Map.of());
         SinkRecord record = mock(SinkRecord.class);
         Schema schema = SchemaBuilder.struct()
                 .field("string_field", Schema.STRING_SCHEMA)
@@ -96,7 +97,7 @@ public class TemplateStrategyTest {
     @Test
     public void metadataStrategyUsesMetadataWithDeliminator() {
         strategy = new KafkaMetadataStrategy();
-        strategy.configure(ImmutableMap.of(KafkaMetadataStrategyConfig.DELIMITER_CONFIG, "_"));
+        strategy.configure(Map.of(KafkaMetadataStrategyConfig.DELIMITER_CONFIG, "_"));
         SinkRecord record = mock(SinkRecord.class);
         when(record.topic()).thenReturn("topic");
         when(record.kafkaPartition()).thenReturn(0);
@@ -110,7 +111,7 @@ public class TemplateStrategyTest {
     public void generatedIdSanitized() {
         strategy = new TemplateStrategy();
         strategy.configure(
-            ImmutableMap.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "#my/special\\id?"));
+            Map.of(TemplateStrategyConfig.TEMPLATE_CONFIG, "#my/special\\id?"));
         SinkRecord record = mock(SinkRecord.class);
 
         String id = strategy.generateId(record);


### PR DESCRIPTION
* Fixed sink bug when using struct type for record value
* Removed guava dependency from test (to avoid security vulnerability)
* Fixes #https://github.com/microsoft/kafka-connect-cosmosdb/issues/493