### PR TITLE
Doesn't allow writing duplicates in bulk writer and corresponding tests

### DIFF
--- a/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/CosmosDBConfig.java
@@ -70,6 +70,10 @@ public class CosmosDBConfig extends AbstractConfig {
     private static final String COSMOS_SINK_BULK_ENABLED_DOC = "Flag to indicate whether Cosmos DB bulk mode is enabled for Sink connector. By default it is true.";
     private static final boolean DEFAULT_COSMOS_SINK_BULK_ENABLED = true;
 
+    public static final String COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED_CONF = "connect.cosmos.sink.bulk.no.duplicates.enabled";
+    private static final String COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED_DOC = "Flag to indicate whether Cosmos DB in bulk mode will allow duplicates in the same batch to be written for Sink connector. By default it is false.";
+    private static final boolean DEFAULT_COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED = false;
+
     public static final String COSMOS_SINK_MAX_RETRY_COUNT = "connect.cosmos.sink.maxRetryCount";
     private static final String COSMOS_SINK_MAX_RETRY_COUNT_DOC =
             "Cosmos DB max retry attempts on write failures for Sink connector. By default, the connector will retry on transient write errors for up to 10 times.";
@@ -94,6 +98,7 @@ public class CosmosDBConfig extends AbstractConfig {
     private final boolean gatewayModeEnabled;
     private final boolean connectionSharingEnabled;
     private final int maxRetryCount;
+    private final boolean bulkModeNoDuplicatesEnabled;
     private TopicContainerMap topicContainerMap = TopicContainerMap.empty();
 
     public CosmosDBConfig(ConfigDef config, Map<String, String> parsedConfig) {
@@ -105,6 +110,7 @@ public class CosmosDBConfig extends AbstractConfig {
         this.topicContainerMap = TopicContainerMap.deserialize(this.getString(COSMOS_CONTAINER_TOPIC_MAP_CONF));
         this.providerName = this.getString(COSMOS_PROVIDER_NAME_CONF);
         this.bulkModeEnabled = this.getBoolean(COSMOS_SINK_BULK_ENABLED_CONF);
+        this.bulkModeNoDuplicatesEnabled = this.getBoolean(COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED_CONF);
         this.maxRetryCount = this.getInt(COSMOS_SINK_MAX_RETRY_COUNT);
         this.gatewayModeEnabled = this.getBoolean(COSMOS_GATEWAY_MODE_ENABLED);
         this.connectionSharingEnabled = this.getBoolean(COSMOS_CONNECTION_SHARING_ENABLED);
@@ -162,6 +168,13 @@ public class CosmosDBConfig extends AbstractConfig {
                         DEFAULT_COSMOS_SINK_BULK_ENABLED,
                         Importance.LOW,
                         COSMOS_SINK_BULK_ENABLED_DOC
+                )
+                .define(
+                        COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED_CONF,
+                        Type.BOOLEAN,
+                        DEFAULT_COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED,
+                        Importance.LOW,
+                        COSMOS_SINK_BULK_NO_DUPLICATES_ENABLED_DOC
                 )
                 .define(
                         COSMOS_SINK_MAX_RETRY_COUNT,
@@ -248,6 +261,10 @@ public class CosmosDBConfig extends AbstractConfig {
 
     public boolean isBulkModeEnabled() {
         return this.bulkModeEnabled;
+    }
+
+    public boolean isBulKNoDuplicatesEnabled() {
+        return this.bulkModeNoDuplicatesEnabled;
     }
 
     public int getMaxRetryCount() {

--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/CosmosDBSinkTask.java
@@ -90,7 +90,7 @@ public class CosmosDBSinkTask extends SinkTask {
             IWriter cosmosdbWriter = this.containerWriterMap.compute(containerName, (name, writer) -> {
                 if (writer == null) {
                     if (this.config.isBulkModeEnabled()) {
-                        writer = new BulkWriter(container, this.config.getMaxRetryCount());
+                        writer = new BulkWriter(container, this.config.getMaxRetryCount(), this.config.isBulKNoDuplicatesEnabled());
                     } else {
                         writer = new PointWriter(container, this.config.getMaxRetryCount());
                     }

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/BulkWriterTests.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/BulkWriterTests.java
@@ -16,6 +16,7 @@ import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosItemOperation;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.PartitionKeyDefinition;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -24,13 +25,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static junit.framework.TestCase.assertEquals;
@@ -42,7 +37,7 @@ import static org.mockito.Mockito.verify;
 public class BulkWriterTests {
     private final int MAX_RETRY_COUNT = 2;
     private final String TOPIC_NAME = "testtopic";
-
+    private final boolean NO_DUPLICATES = true;
     private CosmosContainer container;
     private BulkWriter bulkWriter;
 
@@ -58,7 +53,7 @@ public class BulkWriterTests {
         Mockito.when(mockedContainerProperties.getPartitionKeyDefinition()).thenReturn(mockedPartitionKeyDefinition);
         Mockito.when(mockedPartitionKeyDefinition.getPaths()).thenReturn(Arrays.asList("/id"));
 
-        bulkWriter = new BulkWriter(container, MAX_RETRY_COUNT);
+        bulkWriter = new BulkWriter(container, MAX_RETRY_COUNT, NO_DUPLICATES);
     }
 
     @Test
@@ -79,6 +74,35 @@ public class BulkWriterTests {
         assertEquals(2, response.getSucceededRecords().size());
         assertEquals(record1, response.getSucceededRecords().get(0));
         assertEquals(record2, response.getSucceededRecords().get(1));
+        assertEquals(0, response.getFailedRecordResponses().size());
+    }
+
+    @Test
+    public void testBulkWriteSucceedWithDuplicateIds() {
+        String duplicateId = UUID.randomUUID().toString();
+        String record3Id = UUID.randomUUID().toString();
+        Random rand = new Random();
+        long timestamp1 = rand.nextLong();
+        long timestamp2 = rand.nextLong();
+        SinkRecord record1 = createSinkRecord(duplicateId, Math.min(timestamp1, timestamp2));
+        SinkRecord record2 = createSinkRecord(duplicateId, Math.max(timestamp1, timestamp2));
+        SinkRecord record3 = createSinkRecord(record3Id, rand.nextLong());
+
+        CosmosBulkOperationResponse<Object> successfulResponseForRecord1 = mockSuccessfulBulkOperationResponse(record1, duplicateId);
+        CosmosBulkOperationResponse<Object> successfulResponseForRecord3 = mockSuccessfulBulkOperationResponse(record3, record3Id);
+
+
+        List<CosmosBulkOperationResponse<Object>> mockedBulkOperationResponseList = new ArrayList<>();
+        mockedBulkOperationResponseList.add(successfulResponseForRecord1);
+        mockedBulkOperationResponseList.add(successfulResponseForRecord3);
+
+        Mockito.when(container.executeBulkOperations(any())).thenReturn(() -> mockedBulkOperationResponseList.iterator());
+
+        SinkWriteResponse response = bulkWriter.write(Arrays.asList(record1, record2, record3));
+
+        assertEquals(2, response.getSucceededRecords().size());
+        assertEquals(record1, response.getSucceededRecords().get(0));
+        assertEquals(record3, response.getSucceededRecords().get(1));
         assertEquals(0, response.getFailedRecordResponses().size());
     }
 
@@ -182,8 +206,16 @@ public class BulkWriterTests {
         Map<String, String> map = new HashMap<>();
         map.put("foo", "baaarrrrrgh");
         map.put("id", id);
-
         return new SinkRecord(TOPIC_NAME, 1, stringSchema, "nokey", mapSchema, map, 0L);
+    }
+
+    private SinkRecord createSinkRecord(String id, Long time) {
+        Schema stringSchema = new ConnectSchema(Schema.Type.STRING);
+        Schema mapSchema = new ConnectSchema(Schema.Type.MAP);
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "baaarrrrrgh");
+        map.put("id", id);
+        return new SinkRecord(TOPIC_NAME, 1, stringSchema, "nokey", mapSchema, map, 0L, time, TimestampType.CREATE_TIME);
     }
 
     private CosmosBulkOperationResponse mockSuccessfulBulkOperationResponse(SinkRecord sinkRecord, String partitionKeyValue) {

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/integration/SinkConnectorIT.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/integration/SinkConnectorIT.java
@@ -164,7 +164,8 @@ public class SinkConnectorIT {
             .withConfig("connect.cosmos.connection.endpoint", config.get("connect.cosmos.connection.endpoint").textValue())
             .withConfig("connect.cosmos.master.key", config.get("connect.cosmos.master.key").textValue())
             .withConfig("connect.cosmos.databasename", config.get("connect.cosmos.databasename").textValue())
-            .withConfig("connect.cosmos.containers.topicmap", config.get("connect.cosmos.containers.topicmap").textValue());
+            .withConfig("connect.cosmos.containers.topicmap", config.get("connect.cosmos.containers.topicmap").textValue())
+            .withConfig("connect.cosmos.sink.bulk.no.duplicates.enabled", config.get("connect.cosmos.sink.bulk.no.duplicates.enabled").textValue());
     }
 
     private void addAvroConfigs() {
@@ -221,6 +222,44 @@ public class SinkConnectorIT {
         String sql = String.format("SELECT * FROM c where c.id = '%s'", person.getId());
         CosmosPagedIterable<Person> readResponse = targetContainer.queryItems(sql, new CosmosQueryRequestOptions(), Person.class);
         Optional<Person> retrievedPerson = readResponse.stream().filter(p -> p.getId().equals(person.getId())).findFirst();
+
+        Assert.assertNotNull("Person could not be retrieved", retrievedPerson.orElse(null));
+    }
+
+    @Test
+    public void testPostJsonMessageWithDuplicateIds() throws InterruptedException, ExecutionException {
+        // Configure Kafka Config
+        Properties kafkaProperties = createKafkaProducerProperties();
+        kafkaProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class.getName());
+        producer = new KafkaProducer<>(kafkaProperties);
+
+        // Create sink connector with default config
+        connectClient.addConnector(connectConfig.build());
+
+        // Send Kafka message to topic
+        logger.debug("Sending Kafka message to " + kafkaProperties.getProperty("bootstrap.servers"));
+        String uuid = String.valueOf(RandomUtils.nextLong(1L, 9999999L));
+        Person john = new Person("John", uuid);
+        Person adam = new Person("Adam", uuid);
+        ObjectMapper om = new ObjectMapper();
+        ProducerRecord<String, JsonNode> johnRecord = new ProducerRecord<>(kafkaTopicJson, john.getId(), om.valueToTree(john));
+        ProducerRecord<String, JsonNode> adamRecord = new ProducerRecord<>(kafkaTopicJson, adam.getId(), om.valueToTree(adam));
+        producer.send(johnRecord).get();
+        producer.send(adamRecord).get();
+
+        // Wait a few seconds for the sink connector to push data to Cosmos DB
+        sleep(8000);
+
+        // Query Cosmos DB for data
+        String sql = String.format("SELECT * FROM c where c.id = '%s'", john.getId());
+        CosmosPagedIterable<Person> readResponse = targetContainer.queryItems(sql, new CosmosQueryRequestOptions(), Person.class);
+        Optional<Person> retrievedPerson = readResponse.stream().filter(p -> p.getName().equals(john.getName())).findFirst();
+
+        Assert.assertNull("Person was retrieved", retrievedPerson.orElse(null));
+
+        sql = String.format("SELECT * FROM c where c.id = '%s'", adam.getId());
+        readResponse = targetContainer.queryItems(sql, new CosmosQueryRequestOptions(), Person.class);
+        retrievedPerson = readResponse.stream().filter(p -> p.getName().equals(adam.getName())).findFirst();
 
         Assert.assertNotNull("Person could not be retrieved", retrievedPerson.orElse(null));
     }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
The bulk upsert operation will sometimes write data with duplicate id and partition key incorrectly. This change prevents duplicate items to be sent to the bulk upsert operation. It should only send the latest item. The feature is hidden behind a new config that is set to false by default.

## Observability + Testing
- What changes or considerations did you make in relation to observability?

- Did you add testing to account for any new or changed work?
I added a unit test and a integration test for the changes I made in the bulkwriter. 

## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
