### PR TITLE
SourceConnectorOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release History
+
 ### 1.9.0-beta.1 (Unreleased)
+#### Breaking Changes
+* Skipped updating lease container continuation token based on kafka offset. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
+
 #### Key Bug Fixes
 * Fixed issue in `CosmosDBSourceConnector` where no record being read when configured `connect.cosmos.offset.useLatest` to be false. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 #### Breaking Changes
 * This change will stop updating the lease container continuation token based on kafka offset when using the config `connect.cosmos.offset.useLatest`. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
 
-When set to `false`, if the lease container exists, connector will now process the changes from the current continuationToken in `leaseContainer`, if the lease container does not exist, then it will start from beginning.
+When set to `false`, if the lease container exists, connector will now process the changes from the current continuationToken in `leaseContainer`, if the lease container does not exist, then it will start process the changes from beginning.
 If you want to start from beginning, it is advised to delete the lease container or change the kafka worker name.
 
-when set to `true`, if the lease container exists, connector will now process the changes from the current continuation token in `leaseContainer`, if the lease container does exist, then it will start from now.
+when set to `true`, if the lease container exists, connector will now process the changes from the current continuation token in `leaseContainer`, if the lease container does exist, then it will start process the changes from now.
 
 #### Key Bug Fixes
 * Fixed issue in `CosmosDBSourceConnector` where no record being read when configured `connect.cosmos.offset.useLatest` to be false. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.9.0-beta.1 (Unreleased)
 #### Breaking Changes
-* Skipped updating lease container continuation token based on kafka offset. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
+* This change will stop updating the lease container continuation token based on kafka offset when using the config `connect.cosmos.offset.useLatest = true`, rather it will start the `ChangeFeedProcessor` from now processing changes from the current timestamp. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
 
 #### Key Bug Fixes
 * Fixed issue in `CosmosDBSourceConnector` where no record being read when configured `connect.cosmos.offset.useLatest` to be false. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ### 1.9.0-beta.1 (Unreleased)
 #### Breaking Changes
-* This change will stop updating the lease container continuation token based on kafka offset when using the config `connect.cosmos.offset.useLatest = true`, rather it will start the `ChangeFeedProcessor` from now processing changes from the current timestamp. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
+* This change will stop updating the lease container continuation token based on kafka offset when using the config `connect.cosmos.offset.useLatest`. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
+
+When set to `false`, if the lease container exists, connector will now process the changes from the current continuationToken in `leaseContainer`, if the lease container does not exist, then it will start from beginning.
+If you want to start from beginning, it is advised to delete the lease container or change the kafka worker name.
+
+when set to `true`, if the lease container exists, connector will now process the changes from the current continuation token in `leaseContainer`, if the lease container does exist, then it will start from now.
 
 #### Key Bug Fixes
 * Fixed issue in `CosmosDBSourceConnector` where no record being read when configured `connect.cosmos.offset.useLatest` to be false. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Release History
+### 1.9.0-beta.1 (Unreleased)
+#### Key Bug Fixes
+* Fixed issue in `CosmosDBSourceConnector` where no record being read when configured `connect.cosmos.offset.useLatest` to be false. [PR 516](https://github.com/microsoft/kafka-connect-cosmosdb/pull/516)
 
 ### 1.8.0 (2023-04-12)
 #### New Features

--- a/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTask.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTask.java
@@ -73,6 +73,7 @@ public class CosmosDBSourceTask extends SourceTask {
         
         Map<String, Object> offset = context.offsetStorageReader().offset(partitionMap);
         // If NOT using the latest offset, reset lease container token to earliest possible value
+        // Current behavior
         if (!config.useLatestOffset()) {
             updateContinuationToken(ZERO_CONTINUATION_TOKEN);
         } else if (offset != null) {

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/integration/SourceConnectorIT.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/integration/SourceConnectorIT.java
@@ -7,44 +7,45 @@ import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.kafka.connect.IntegrationTest;
 import com.azure.cosmos.models.CosmosContainerProperties;
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.ThroughputProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.json.JsonDeserializer;
-import org.sourcelab.kafka.connect.apiclient.Configuration;
-import org.sourcelab.kafka.connect.apiclient.KafkaConnectClient;
-import org.sourcelab.kafka.connect.apiclient.request.dto.NewConnectorDefinition;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-
-import com.azure.cosmos.kafka.connect.IntegrationTest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sourcelab.kafka.connect.apiclient.Configuration;
+import org.sourcelab.kafka.connect.apiclient.KafkaConnectClient;
+import org.sourcelab.kafka.connect.apiclient.request.dto.NewConnectorDefinition;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Arrays;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.time.Duration;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.sleep;
 import static org.sourcelab.kafka.connect.apiclient.request.dto.NewConnectorDefinition.Builder;
@@ -78,6 +79,7 @@ public class SourceConnectorIT {
     private KafkaConsumer<String, GenericRecord> avroConsumer;
     private List<ConsumerRecord<String, JsonNode>> recordBuffer;
     private List<ConsumerRecord<String, GenericRecord>> avroRecordBuffer;
+    private String leaseContainerName;
 
     /**
      * Load CosmosDB configuration from the connector config JSON and set up CosmosDB client.
@@ -93,7 +95,7 @@ public class SourceConnectorIT {
         String topicContainerMap = config.get("connect.cosmos.containers.topicmap").textValue();
         String topic = StringUtils.substringBefore(topicContainerMap, "#");
         String containerName = StringUtils.substringAfter(topicContainerMap, "#");
-
+        this.leaseContainerName = containerName + "-leases";
         // Setup Cosmos Client
         logger.debug("Setting up the Cosmos DB client");
         cosmosClient = new CosmosClientBuilder()
@@ -493,6 +495,101 @@ public class SourceConnectorIT {
         Assert.assertNotNull("Person A could not be retrieved from messages", resultRecord.orElse(null));
         resultRecord = searchConsumerRecords(secondPerson);
         Assert.assertNotNull("Person B could not be retrieved from messages", resultRecord.orElse(null));
+    }
+
+    /**
+     * Test when lease container is not initialized and connect.cosmos.offset.useLatest = false
+     * the change feed should start processing from beginning
+     */
+    @Test
+    public void testStart_notUseLatestOffset() {
+
+        // Delete previous created lease container
+        try {
+            cosmosClient.getDatabase(this.databaseName).getContainer(this.leaseContainerName).delete();
+        } catch (CosmosException e) {
+            if (e.getStatusCode() == 404) {
+                logger.info("Lease container does not exists");
+            } else {
+                throw e;
+            }
+        }
+
+        // Create source connector with default config
+        connectClient.addConnector(connectConfig.build());
+
+        // Allow time for Source connector to setup resources
+        sleep(8000);
+
+        // Create item in Cosmos DB
+        Person person = new Person("Lucy Ferr", RandomUtils.nextLong(1L, 9999999L) + "");
+        targetContainer.createItem(person);
+
+        // Allow time for Source connector to process data from Cosmos DB
+        sleep(8000);
+        // Verify the lease document continuationToken is not null and > 0
+        List<JsonNode> leaseDocuments = this.getAllLeaseDocuments();
+        for (JsonNode leaseDocument : leaseDocuments) {
+            Assert.assertTrue(
+                    Integer.parseInt(leaseDocument.get("ContinuationToken").asText().replace("\"", "")) > 0);
+        }
+    }
+
+    /**
+     * Test when lease container is not initialized and connect.cosmos.offset.useLatest = true
+     * the change feed should start processing from now
+     */
+    @Test
+    public void testStart_useLatestOffset() {
+
+        // Delete previous created lease container
+        try {
+            cosmosClient.getDatabase(this.databaseName).getContainer(this.leaseContainerName).delete();
+        } catch (CosmosException e) {
+            if (e.getStatusCode() == 404) {
+                logger.info("Lease container does not exists");
+            } else {
+                throw e;
+            }
+        }
+
+        // Create item before the task start
+        Person person = new Person("Lucy Ferr", RandomUtils.nextLong(1L, 9999999L) + "");
+        targetContainer.createItem(person);
+
+        // Create source connector with default config
+        connectClient.addConnector(
+                connectConfig.withConfig("connect.cosmos.offset.useLatest", true).build());
+
+        // Allow time for Source connector to setup resources
+        sleep(10000);
+
+        // Verify the lease document continuationToken will be null
+        List<JsonNode> leaseDocuments = this.getAllLeaseDocuments();
+        for (JsonNode leaseDocument : leaseDocuments) {
+            Assert.assertTrue(leaseDocument.get("ContinuationToken").isNull());
+        }
+
+        // now create some new items
+        person = new Person("Lucy Ferr", RandomUtils.nextLong(1L, 9999999L) + "");
+        targetContainer.createItem(person);
+        // Allow time for Source connector to setup resources
+        sleep(10000);
+
+        // Verify the lease document continuationToken will be null
+        leaseDocuments = this.getAllLeaseDocuments();
+        for (JsonNode leaseDocument : leaseDocuments) {
+            Assert.assertTrue(
+                    Integer.parseInt(leaseDocument.get("ContinuationToken").asText().replace("\"", "")) > 0);        }
+    }
+
+    private List<JsonNode> getAllLeaseDocuments() {
+        String sql = "SELECT * FROM c WHERE IS_DEFINED(c.Owner)";
+        return this.cosmosClient
+                .getDatabase(this.databaseName)
+                .getContainer(this.leaseContainerName)
+                .queryItems(sql, new CosmosQueryRequestOptions(), JsonNode.class)
+                .stream().collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
**Changes included:**
1. Ignore Kafka offset and always depend on ChangeFeedProcessor to track the task progress. 
2. When `connect.cosmos.offset.useLatest = false` :  create changeFeedProcessor with startFromBeginning(true)
3. When `connect.cosmos.offset.useLatest = true`:  create changeFeedProcessor with startFromBeginning(false)

The above change fixed the following issues has been reported by customer:
1. When lease container is not initialized, setting `connect.cosmos.offset.useLatest = true` cause no changes being read
2. When lease container is initialized, setting `connect.cosmos.offset.useLatest = true` cause only one lease being updated to have continuationToken 0

**Tests:**
Run e2e cases with lease container not initialized and `connect.cosmos.offset.useLatest = false`, all the pre-created records have been pushed to topic





