### PR TITLE
fixed bug in test and fixed hashcode method

### DIFF
--- a/src/main/java/com/azure/cosmos/kafka/connect/sink/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/sink/BulkWriter.java
@@ -198,7 +198,7 @@ public class BulkWriter extends SinkWriterBase {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, partitionKey);
+            return Objects.hash(id, partitionKey.toString());
         }
     }
 

--- a/src/test/java/com/azure/cosmos/kafka/connect/sink/BulkWriterTests.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/sink/BulkWriterTests.java
@@ -95,12 +95,12 @@ public class BulkWriterTests {
         SinkRecord record2 = createSinkRecord(duplicateId, Math.max(timestamp1, timestamp2));
         SinkRecord record3 = createSinkRecord(record3Id, rand.nextLong());
 
-        CosmosBulkOperationResponse<Object> successfulResponseForRecord1 = mockSuccessfulBulkOperationResponse(record1, duplicateId);
+        CosmosBulkOperationResponse<Object> successfulResponseForRecord2 = mockSuccessfulBulkOperationResponse(record2, duplicateId);
         CosmosBulkOperationResponse<Object> successfulResponseForRecord3 = mockSuccessfulBulkOperationResponse(record3, record3Id);
 
 
         List<CosmosBulkOperationResponse<Object>> mockedBulkOperationResponseList = new ArrayList<>();
-        mockedBulkOperationResponseList.add(successfulResponseForRecord1);
+        mockedBulkOperationResponseList.add(successfulResponseForRecord2);
         mockedBulkOperationResponseList.add(successfulResponseForRecord3);
 
         Mockito.when(container.executeBulkOperations(any())).thenReturn(() -> mockedBulkOperationResponseList.iterator());
@@ -108,7 +108,7 @@ public class BulkWriterTests {
         SinkWriteResponse response = bulkWriter.write(Arrays.asList(record1, record2, record3));
 
         assertEquals(2, response.getSucceededRecords().size());
-        assertEquals(record1, response.getSucceededRecords().get(0));
+        assertEquals(record2, response.getSucceededRecords().get(0));
         assertEquals(record3, response.getSucceededRecords().get(1));
         assertEquals(0, response.getFailedRecordResponses().size());
     }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
The test was comparing the wrong duplicate item. The hashcode for partition key uses the object hashcode, so it is based on reference. Therefore, changed it to use the hascode of the tostring of the partition key to fix functionality. 
## Observability + Testing
- What changes or considerations did you make in relation to observability?

- Did you add testing to account for any new or changed work?


## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
