### PR TITLE
fixInfiniteLoopIssueWhenSourceTaskGotCancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Release History
+### 1.13.0-beta.1 (Unreleased)
+#### Other Changes
+* Fixed an issue where source connector can be stuck in an infinite loop when task got cancelled. [PR 545](https://github.com/microsoft/kafka-connect-cosmosdb/pull/545) 
+
 ### 1.12.0 (2023-12-18)
 #### New Features
 * Updated `azure-cosmos` version to 4.53.1.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.azure.cosmos.kafka</groupId>
     <artifactId>kafka-connect-cosmos</artifactId>
-    <version>1.12.0</version>
+    <version>1.13.0-beta.1</version>
 
     <name> kafka-connect-cosmos</name>
     <url>https://github.com/microsoft/kafka-connect-cosmosdb</url>

--- a/src/main/java/com/azure/cosmos/kafka/connect/implementations/CosmosKafkaSchedulers.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/implementations/CosmosKafkaSchedulers.java
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementations;
+
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+public class CosmosKafkaSchedulers {
+    private final static String COSMOS_KAFKA_CFP_THREAD_NAME = "cosmos-kafka-cfp-bounded-elastic";
+    private final static int TTL_FOR_SCHEDULER_WORKER_IN_SECONDS = 60; // same as BoundedElasticScheduler.DEFAULT_TTL_SECONDS
+
+    // Custom bounded elastic scheduler for kafka connector
+    public final static Scheduler COSMOS_KAFKA_CFP_BOUNDED_ELASTIC = Schedulers.newBoundedElastic(
+            Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE,
+            Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+            COSMOS_KAFKA_CFP_THREAD_NAME,
+            TTL_FOR_SCHEDULER_WORKER_IN_SECONDS,
+            true
+    );
+}

--- a/src/main/java/com/azure/cosmos/kafka/connect/implementations/CosmosKafkaSchedulers.java
+++ b/src/main/java/com/azure/cosmos/kafka/connect/implementations/CosmosKafkaSchedulers.java
@@ -7,11 +7,11 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 public class CosmosKafkaSchedulers {
-    private final static String COSMOS_KAFKA_CFP_THREAD_NAME = "cosmos-kafka-cfp-bounded-elastic";
-    private final static int TTL_FOR_SCHEDULER_WORKER_IN_SECONDS = 60; // same as BoundedElasticScheduler.DEFAULT_TTL_SECONDS
+    private static final String COSMOS_KAFKA_CFP_THREAD_NAME = "cosmos-kafka-cfp-bounded-elastic";
+    private static final int TTL_FOR_SCHEDULER_WORKER_IN_SECONDS = 60; // same as BoundedElasticScheduler.DEFAULT_TTL_SECONDS
 
     // Custom bounded elastic scheduler for kafka connector
-    public final static Scheduler COSMOS_KAFKA_CFP_BOUNDED_ELASTIC = Schedulers.newBoundedElastic(
+    public static final Scheduler COSMOS_KAFKA_CFP_BOUNDED_ELASTIC = Schedulers.newBoundedElastic(
             Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE,
             Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
             COSMOS_KAFKA_CFP_THREAD_NAME,

--- a/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTaskTest.java
+++ b/src/test/java/com/azure/cosmos/kafka/connect/source/CosmosDBSourceTaskTest.java
@@ -271,6 +271,8 @@ public class CosmosDBSourceTaskTest {
             testTask.handleCosmosDbChanges(changes);
         }).start();
 
+        Thread.sleep(500); // give some time for the above task to run
+
         testTask.stop();
         AtomicBoolean isRunning =
             (AtomicBoolean) FieldUtils.readField(


### PR DESCRIPTION
**Issue:**
Post [this](https://github.com/apache/kafka/pull/9669) change in kafka connect framework the connector uses a single thread for both
poll() as well as for stop(). Before that change,
the SourceTask::stop method would be invoked on a separate thread from
the one that did the actual data processing for the task (polling the task
for records, transforming and converting those records, then sending them
to Kafka). After that change, SourceTask::stop() is being invoked on the
same thread that handled data processing for the task. This had the effect
that tasks which blocked indefinitely in the SourceTask::poll method with the expectation
that they could stop blocking when SourceTask::stop
was invoked would no longer be capable of graceful shutdown, and may even
hang forever and the reverse is also true. Which is if stop() sleeps on the thread forever
then poll() would never be able to continue.

This issue also related to https://github.com/microsoft/kafka-connect-cosmosdb/discussions/543

**Changes:**
1. Remove the empty check from the stop() method
2. Adding .block when calling changeFeedProcessor.stop(), else the changeFeedProcessor will not be stopped and all internal tasks are still running
3. using dedicated Kafka-cfp-bounded-elastic schedulers 