### PR TITLE
1.17.0 Release

### DIFF
--- a/.github/workflows/mavenCI.yml
+++ b/.github/workflows/mavenCI.yml
@@ -31,7 +31,7 @@ jobs:
       run: ./src/docker/startup.ps1
       if: github.ref == 'refs/heads/main'
     - name: Upload JaCoCo coverage report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jacoco-report
         path: target/site/jacoco/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Release History
 ### 1.17.0 (2025-02-24)
-#### New Features
-* Updated `azure-cosmos` version to 4.67.0.
+#### Key Bug Fixes
+* Updated `azure-cosmos` version to 4.67.0 to address these security vulnerabilities.
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-25193,
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-24970
+* Added direct dependency on json smart to address the security vulnerability. - [PR 579](https://github.com/microsoft/kafka-connect-cosmosdb/pull/579/files)
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-57699
 
 ### 1.16.0 (2024-11-21)
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Updated `azure-cosmos` version to 4.67.0 to address these security vulnerabilities.
   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-25193,
   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-24970
-* Added direct dependency on json smart to address the security vulnerability. - [PR 579](https://github.com/microsoft/kafka-connect-cosmosdb/pull/579/files)
+* Added direct dependency on json smart to address the security vulnerability. - [PR 579](https://github.com/microsoft/kafka-connect-cosmosdb/pull/579)
   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-57699
 
 ### 1.16.0 (2024-11-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## Release History
+### 1.17.0 (2025-02-24)
+#### New Features
+* Updated `azure-cosmos` version to 4.67.0.
+
+### 1.16.0 (2024-11-21)
+#### New Features
+* Updated `azure-cosmos` version to 4.65.0.
+
 ### 1.15.0 (2024-04-18)
 #### Key Bug Fixes
 * Fixed an issue where using `CosmosDBSinkConnector` in bulk mode failed to write items for container with nested partition key path - [PR 565](https://github.com/microsoft/kafka-connect-cosmosdb/pull/565)

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.azure.cosmos.kafka</groupId>
     <artifactId>kafka-connect-cosmos</artifactId>
-    <version>1.15.0</version>
+    <version>1.17.0</version>
 
     <name> kafka-connect-cosmos</name>
     <url>https://github.com/microsoft/kafka-connect-cosmosdb</url>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
-            <version>4.58.0</version>
+            <version>4.67.0</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
         </dependency>
+        <!-- remove once jsonpath increments version -->
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
+        </dependency>
 
         <!-- Apache commons -->
         <dependency>


### PR DESCRIPTION
- Increasing the cosmos version and prepping for a release
- Increased upload artifacts version to v4 because v3 is deprecated
- Took direct dependency on json smart
