### PR TITLE
Bump azure-cosmos to 4.80.0 to address jackson / netty CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release History
 
+### 1.20.0 (Unreleased)
+#### Other Changes
+* Updated `azure-cosmos` version to `4.80.0`.
+
 ### 1.19.0 (2026-01-27)
 #### Key Bug Fixes
 * Updated `azure-cosmos` version to `4.77.0` to address these security vulnerabilities. - [PR 585](https://github.com/microsoft/kafka-connect-cosmosdb/pull/585)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 ## Release History
 
-### 1.20.0 (Unreleased)
-#### Key Bug Fixes
-* Updated `azure-cosmos` version to `4.80.0` to pick up patched transitive dependencies (`jackson-core` `2.18.6` and `netty` `4.1.132.Final`) that address the following security vulnerabilities:
-  https://github.com/advisories/GHSA-72hv-8253-57qq
-  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-33870
-  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-33871
-
 ### 1.19.0 (2026-01-27)
 #### Key Bug Fixes
 * Updated `azure-cosmos` version to `4.77.0` to address these security vulnerabilities. - [PR 585](https://github.com/microsoft/kafka-connect-cosmosdb/pull/585)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Release History
 
+### 1.20.0 (Unreleased)
+#### Key Bug Fixes
+* Updated `azure-cosmos` version to `4.80.0` to pick up patched transitive dependencies (`jackson-core` `2.18.6` and `netty` `4.1.132.Final`) that address the following security vulnerabilities:
+  https://github.com/advisories/GHSA-72hv-8253-57qq
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-33870
+  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-33871
+
 ### 1.19.0 (2026-01-27)
 #### Key Bug Fixes
 * Updated `azure-cosmos` version to `4.77.0` to address these security vulnerabilities. - [PR 585](https://github.com/microsoft/kafka-connect-cosmosdb/pull/585)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.20.0 (Unreleased)
 #### Other Changes
-* Updated `azure-cosmos` version to `4.80.0`.
+* Updated `azure-cosmos` version to `4.80.0`. - [PR 593](https://github.com/microsoft/kafka-connect-cosmosdb/pull/593)
 
 ### 1.19.0 (2026-01-27)
 #### Key Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
-            <version>4.77.0</version>
+            <version>4.80.0</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
## Description

Addresses three security vulnerabilities reported against the published `microsoftcorporation-kafka-connect-cosmos` v1.18.0 connector (Confluent Hub) that remain unaddressed after the v1.19.0 release. The `log4j-core` and netty `CVE-2025-67735` items from the same scan are already fixed on `master` (log4j is at `2.25.3`, and `azure-cosmos` `4.77.0` brings netty `4.1.130.Final` which patches `CVE-2025-67735`).

| CVE / Advisory | Package | Installed (via azure-cosmos 4.77.0) | Fixed (via azure-cosmos 4.80.0) | Severity |
|---|---|---|---|---|
| [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) | `com.fasterxml.jackson.core:jackson-core` | 2.18.4.1 | **2.18.6** | MEDIUM |
| [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870) | `io.netty:netty-codec-http` | 4.1.130.Final | **4.1.132.Final** | HIGH |
| [CVE-2026-33871](https://nvd.nist.gov/vuln/detail/CVE-2026-33871) | `io.netty:netty-codec-http2` | 4.1.130.Final | **4.1.132.Final** | HIGH |

## Changes

- `pom.xml` — bump `com.azure:azure-cosmos` from `4.77.0` to `4.80.0` (latest GA at time of writing). `azure-cosmos` 4.80.0 → `azure-core` 1.58.0 (which pins `jackson-core` 2.18.6) and `azure-core-http-netty` 1.16.4 (which pins netty 4.1.132.Final).
- `CHANGELOG.md` — add a new `1.20.0 (Unreleased)` entry documenting the CVE fixes.

## Why not pin jackson / netty explicitly?

`azure-cosmos` already aligns the full jackson and netty families to patched versions. Adding explicit pins here would duplicate that alignment point, risk version skew against `jackson-databind` / `jackson-annotations` / the rest of the netty family, and be silently overridden by future `azure-cosmos` bumps. Letting the transitive chain do the work is the lower-risk option and matches what v1.19.0 already did for `CVE-2025-67735`.

## Related

A parallel fix for the v2 connector (`azure-cosmos-kafka-connect` in `Azure/azure-sdk-for-java`) is being made in [Azure/azure-sdk-for-java#49150](https://github.com/Azure/azure-sdk-for-java/pull/49150).
